### PR TITLE
neatened up HTTP verb usage

### DIFF
--- a/app/uk/gov/hmrc/helptosave/connectors/ITMPEnrolmentConnector.scala
+++ b/app/uk/gov/hmrc/helptosave/connectors/ITMPEnrolmentConnector.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.helptosave.connectors
 
 import cats.data.EitherT
 import com.google.inject.{ImplementedBy, Inject, Singleton}
+import play.api.libs.json.{JsNull, JsValue}
 import play.api.mvc.Results.EmptyContent
 import play.mvc.Http.Status.{FORBIDDEN, OK}
 import uk.gov.hmrc.helptosave.config.WSHttp
@@ -47,7 +48,7 @@ class ITMPEnrolmentConnectorImpl @Inject() (http: WSHttp, metrics: Metrics) exte
 
   val header: Map[String, String] = Map("Environment" → environment)
 
-  val body: EmptyContent = EmptyContent()
+  val body: JsValue = JsNull
 
   def url(nino: NINO): String = s"$itmpEnrolmentURL/help-to-save/accounts/$nino"
 

--- a/app/uk/gov/hmrc/helptosave/util/HeaderCarrierOps.scala
+++ b/app/uk/gov/hmrc/helptosave/util/HeaderCarrierOps.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.util
+
+import uk.gov.hmrc.http.HeaderCarrier
+
+object HeaderCarrierOps {
+
+  implicit class HeaderCarrierOps(val hc: HeaderCarrier) extends AnyVal {
+    def withExtraHeaders(headers: Map[String, String]): HeaderCarrier =
+      hc.copy(extraHeaders = hc.extraHeaders ++ headers.toSeq)
+  }
+
+}
+

--- a/test/uk/gov/hmrc/helptosave/connectors/EligibilityCheckConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/connectors/EligibilityCheckConnectorSpec.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.test.WithFakeApplication
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 class EligibilityCheckConnectorSpec extends TestSupport with WithFakeApplication with GeneratorDrivenPropertyChecks with ServicesConfig {
 
@@ -36,8 +36,8 @@ class EligibilityCheckConnectorSpec extends TestSupport with WithFakeApplication
   lazy val connector = new EligibilityCheckConnectorImpl(mockHttp, mockMetrics)
 
   def mockGet(url: String)(response: HttpResponse) =
-    (mockHttp.get(_: String, _: Map[String, String])(_: HeaderCarrier))
-      .expects(url, connector.headers, *)
+    (mockHttp.get(_: String, _: Map[String, String])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(url, connector.headers, *, *)
       .returning(Future.successful(response))
 
   implicit val resultArb: Arbitrary[EligibilityCheckResult] = Arbitrary(for {

--- a/test/uk/gov/hmrc/helptosave/connectors/ITMPEnrolmentConnectorImplSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/connectors/ITMPEnrolmentConnectorImplSpec.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.helptosave.connectors
 
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import play.api.http.Writeable
-import play.api.mvc.Results.EmptyContent
+import play.api.libs.json.{JsNull, Writes}
 import uk.gov.hmrc.helptosave.util.NINO
 import uk.gov.hmrc.helptosave.utils.TestSupport
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
@@ -33,7 +32,7 @@ class ITMPEnrolmentConnectorImplSpec extends TestSupport with WithFakeApplicatio
   lazy val environment: String = connector.environment
 
   def mockPut[A](url: String, body: A)(result: Option[HttpResponse]): Unit =
-    (mockHttp.put(_: String, _: A, _: Map[String, String])(_: Writeable[A], _: HeaderCarrier, _: ExecutionContext))
+    (mockHttp.put(_: String, _: A, _: Map[String, String])(_: Writes[A], _: HeaderCarrier, _: ExecutionContext))
       .expects(url, body, Map("Environment" → environment), *, *, *)
       .returning(result.fold[Future[HttpResponse]](Future.failed(new Exception("")))(Future.successful))
 
@@ -46,19 +45,19 @@ class ITMPEnrolmentConnectorImplSpec extends TestSupport with WithFakeApplicatio
     "setting the ITMP flag" must {
 
       "perform a post to the configured URL" in {
-        mockPut(url(nino), EmptyContent())(None)
+        mockPut(url(nino), JsNull)(None)
 
         await(connector.setFlag(nino).value)
       }
 
       "return a Right if the call to ITMP comes back with a 200 (OK) status" in {
-        mockPut(url(nino), EmptyContent())(Some(HttpResponse(200)))
+        mockPut(url(nino), JsNull)(Some(HttpResponse(200)))
 
         await(connector.setFlag(nino).value) shouldBe Right(())
       }
 
       "return a Right if the call to ITMP comes back with a 403 (FORBIDDEN) status" in {
-        mockPut(url(nino), EmptyContent())(Some(HttpResponse(403)))
+        mockPut(url(nino), JsNull)(Some(HttpResponse(403)))
 
         await(connector.setFlag(nino).value) shouldBe Right(())
       }
@@ -68,7 +67,7 @@ class ITMPEnrolmentConnectorImplSpec extends TestSupport with WithFakeApplicatio
         "the call to ITMP comes back with a status which isn't 200 or 403" in {
           forAll{ status: Int ⇒
             whenever(status != 200 && status != 403){
-              mockPut(url(nino), EmptyContent())(Some(HttpResponse(status)))
+              mockPut(url(nino), JsNull)(Some(HttpResponse(status)))
 
               await(connector.setFlag(nino).value).isLeft shouldBe true
             }
@@ -76,7 +75,7 @@ class ITMPEnrolmentConnectorImplSpec extends TestSupport with WithFakeApplicatio
         }
 
         "an error occurs while calling the ITMP endpoint" in {
-          mockPut(url(nino), EmptyContent())(None)
+          mockPut(url(nino), JsNull)(None)
           await(connector.setFlag(nino).value).isLeft shouldBe true
         }
 


### PR DESCRIPTION
We have custom logic on top of `http-verbs` to avoid having to handle their library throwing exceptions. For the `GET` method the exceptions were being thrown here:

https://github.com/hmrc/http-verbs/blob/master/src/main/scala/uk/gov/hmrc/http/HttpGet.scala#L32

Here, instead of copying and pasting the code there without the exception throwing stuff I've overriden the `mapErrors` function to do nothing and implemented a custom `HttpReads` to do nothing 