### PR TITLE
[FD,BL] NGC-3251 Add Get Transactions endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,48 @@ This microservice is deployed as per all MDTP microservices via Jenkins into a D
  If the call is successful, expect a `200` response with JSON containing the eligibility result. If call is not successful expect a `500`
  response.
 
+# GET /:nino/account
+ Returns account data for the specified NINO (National Insurance Number), or 404 if there is no account for that NINO.
+ 
+# GET /:nino/account/transactions
+ Returns transaction for the specified NINO (National Insurance Number), or 404 if there is no account for that NINO.
+ 
+  The JSON format for successful `200` responses is:
+
+```json  
+{
+  "transactions": [
+    {
+      "amount": 3.00,
+      "operation": "credit",
+      "transactionDate": "2018-02-18",
+      "accountingDate": "2018-02-18",
+      "description": "Debit card online deposit",
+      "transactionReference": "A1A11AA1A00A0034",
+      "balanceAfter": 3.00
+    },
+    {
+      "amount": 6.67,
+      "operation": "debit",
+      "transactionDate": "2018-02-20",
+      "accountingDate": "2018-02-22",
+      "description": "BACS payment",
+      "transactionReference": "A1A11AA1A00A000I",
+      "balanceAfter": 9.67
+    },
+    {
+      "amount": 5.00,
+      "operation": "debit",
+      "transactionDate": "2018-02-25",
+      "accountingDate": "2018-02-25",
+      "description": "BACS payment",
+      "transactionReference": "A1A11AA1A00A000G",
+      "balanceAfter": 4.67
+    }
+  ]
+}
+```
+
 # GET /enrolment-status
  Checks whether or not a person is enrolled in help to save. This endpoint requires no parameters.
 

--- a/app/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnector.scala
+++ b/app/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnector.scala
@@ -183,7 +183,7 @@ class HelpToSaveProxyConnectorImpl @Inject() (http:              WSHttp,
               result.bimap(
                 { e ⇒
                   metrics.getTransactionsErrorCounter.inc()
-                  pagerDutyAlerting.alert("Could not parse JSON in the get transactions response")
+                  pagerDutyAlerting.alert("Could not parse get transactions response")
                   s"Could not parse transactions response from NS&I, received 200 (OK), error=$e"
                 },
                 { transactions ⇒

--- a/app/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnector.scala
+++ b/app/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnector.scala
@@ -23,19 +23,19 @@ import cats.instances.int._
 import cats.instances.string._
 import cats.syntax.either._
 import cats.syntax.eq._
-
 import com.google.inject.{ImplementedBy, Inject, Singleton}
+import io.lemonlabs.uri.dsl._
 import play.api.http.Status
 import play.api.libs.json.{Format, Json}
 import play.mvc.Http.Status.INTERNAL_SERVER_ERROR
 import uk.gov.hmrc.helptosave.config.{AppConfig, WSHttp}
 import uk.gov.hmrc.helptosave.metrics.Metrics
-import uk.gov.hmrc.helptosave.models.account.{Account, NsiAccount}
+import uk.gov.hmrc.helptosave.models.account.{Account, NsiAccount, NsiTransactions, Transactions}
 import uk.gov.hmrc.helptosave.models.{ErrorResponse, NSIUserInfo, UCResponse}
 import uk.gov.hmrc.helptosave.util.HeaderCarrierOps._
 import uk.gov.hmrc.helptosave.util.HttpResponseOps._
 import uk.gov.hmrc.helptosave.util.Logging._
-import uk.gov.hmrc.helptosave.util.{LogMessageTransformer, Logging, PagerDutyAlerting, Result, maskNino}
+import uk.gov.hmrc.helptosave.util.{LogMessageTransformer, Logging, PagerDutyAlerting, Result}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -52,6 +52,8 @@ trait HelpToSaveProxyConnector {
    * If NS&I do not recognise the given NINO return None
    */
   def getAccount(nino: String, systemId: String, correlationId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[Option[Account]]
+
+  def getTransactions(nino: String, systemId: String, correlationId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[Option[Transactions]]
 }
 
 @Singleton
@@ -65,8 +67,9 @@ class HelpToSaveProxyConnectorImpl @Inject() (http:              WSHttp,
   val proxyURL: String = appConfig.baseUrl("help-to-save-proxy")
 
   val getAccountVersion: String = appConfig.runModeConfiguration.underlying.getString("nsi.get-account.version")
+  val getTransactionsVersion: String = appConfig.runModeConfiguration.underlying.getString("nsi.get-transactions.version")
 
-  val getAccountNoAccountErrorCode: String = appConfig.runModeConfiguration.underlying.getString("nsi.get-account.no-account-error-message-id")
+  val noAccountErrorCode: String = appConfig.runModeConfiguration.underlying.getString("nsi.no-account-error-message-id")
 
   override def createAccount(userInfo: NSIUserInfo)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
 
@@ -113,7 +116,7 @@ class HelpToSaveProxyConnectorImpl @Inject() (http:              WSHttp,
 
   override def getAccount(nino: String, systemId: String, correlationId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Result[Option[Account]] = {
 
-    val url = s"$proxyURL/help-to-save-proxy/nsi-services/account?nino=$nino&correlationId=$correlationId&version=$getAccountVersion&systemId=$systemId"
+    val url = s"$proxyURL/help-to-save-proxy/nsi-services/account" ? ("nino" -> nino) & ("correlationId" -> correlationId) & ("version" -> getAccountVersion) & ("systemId" -> systemId)
     val timerContext = metrics.getAccountTimer.time()
     EitherT[Future, String, Option[Account]](
       http.get(url).map[Either[String, Option[Account]]] {
@@ -121,19 +124,20 @@ class HelpToSaveProxyConnectorImpl @Inject() (http:              WSHttp,
           val _ = timerContext.stop()
           response.status match {
             case Status.OK ⇒
-              val result = response.parseJson[NsiAccount].flatMap(a ⇒
+              val result = response.parseJsonWithoutLoggingBody[NsiAccount].flatMap(a ⇒
                 Account(a).toEither.bimap(s ⇒ s"[${s.toList.mkString(",")}]", Some(_)))
 
-              result.fold(
-                e ⇒ {
-                  // avoid logging PPI here by not logging the response body
-                  logger.warn(s"Could not parse getNsiAccount response, received 200 (OK), error=$e", nino, "correlationId" → correlationId)
+              result.bimap(
+                { e ⇒
                   metrics.getAccountErrorCounter.inc()
                   pagerDutyAlerting.alert("Could not parse JSON in the getAccount response")
+                  s"Could not parse getNsiAccount response, received 200 (OK), error=$e"
                 },
-                _ ⇒ logger.info("Call to getNsiAccount successful", nino, "correlationId" → correlationId)
+                { transactions ⇒
+                  logger.info("Call to getNsiAccount successful", nino, "correlationId" → correlationId)
+                  transactions
+                }
               )
-              result
 
             case other ⇒
               if (isAccountDoesntExistResponse(response)) {
@@ -159,9 +163,61 @@ class HelpToSaveProxyConnectorImpl @Inject() (http:              WSHttp,
     )
   }
 
+  override def getTransactions(
+      nino: String, systemId: String, correlationId: String)(
+      implicit
+      hc: HeaderCarrier, ec: ExecutionContext): Result[Option[Transactions]] = {
+
+    val url = s"$proxyURL/help-to-save-proxy/nsi-services/transactions" ? ("nino" -> nino) & ("correlationId" -> correlationId) & ("version" -> getTransactionsVersion) & ("systemId" -> systemId)
+
+    val timerContext = metrics.getTransactionsTimer.time()
+    EitherT[Future, String, Option[Transactions]](
+      http.get(url).map[Either[String, Option[Transactions]]] {
+        response ⇒
+          val _ = timerContext.stop()
+          response.status match {
+            case Status.OK ⇒
+              val result = response.parseJsonWithoutLoggingBody[NsiTransactions].flatMap(nsiTransactions ⇒
+                Transactions(nsiTransactions).toEither.bimap(s ⇒ s"[${s.toList.mkString(",")}]", Some(_)))
+
+              result.bimap(
+                { e ⇒
+                  metrics.getTransactionsErrorCounter.inc()
+                  pagerDutyAlerting.alert("Could not parse JSON in the get transactions response")
+                  s"Could not parse transactions response from NS&I, received 200 (OK), error=$e"
+                },
+                { transactions ⇒
+                  logger.info("Call to get transactions successful", nino, "correlationId" → correlationId)
+                  transactions
+                })
+
+            case other ⇒
+              if (isAccountDoesntExistResponse(response)) {
+                logger.info("Account didn't exist for get transactions request", nino, "correlationId" → correlationId)
+                Right(None)
+              } else {
+                logger.warn(s"Call to get transactions unsuccessful. Received unexpected status $other. Body was ${response.body}",
+                  nino, "correlationId" → correlationId)
+                metrics.getTransactionsErrorCounter.inc()
+                pagerDutyAlerting.alert("Received unexpected http status in response to get transactions")
+
+                Left(s"Received unexpected status($other) from get transactions call")
+              }
+          }
+      }.recover {
+        case NonFatal(e) ⇒
+          val _ = timerContext.stop()
+          metrics.getTransactionsErrorCounter.inc()
+          logger.warn("Failed to make call to get transactions", e)
+          pagerDutyAlerting.alert("Failed to make call to get transactions")
+          Left(s"Call to get transactions unsuccessful: ${e.getMessage}")
+      }
+    )
+  }
+
   private def isAccountDoesntExistResponse(response: HttpResponse): Boolean =
     response.status === Status.BAD_REQUEST &&
-      response.parseJson[GetAccountErrorResponse].toOption.exists(_.errors.exists(_.errorMessageId === getAccountNoAccountErrorCode))
+      response.parseJson[GetAccountErrorResponse].toOption.exists(_.errors.exists(_.errorMessageId === noAccountErrorCode))
 }
 
 object HelpToSaveProxyConnectorImpl {

--- a/app/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnector.scala
+++ b/app/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnector.scala
@@ -133,9 +133,9 @@ class HelpToSaveProxyConnectorImpl @Inject() (http:              WSHttp,
                   pagerDutyAlerting.alert("Could not parse JSON in the getAccount response")
                   s"Could not parse getNsiAccount response, received 200 (OK), error=$e"
                 },
-                { transactions ⇒
+                { account ⇒
                   logger.info("Call to getNsiAccount successful", nino, "correlationId" → correlationId)
-                  transactions
+                  account
                 }
               )
 

--- a/app/uk/gov/hmrc/helptosave/controllers/AccountController.scala
+++ b/app/uk/gov/hmrc/helptosave/controllers/AccountController.scala
@@ -28,7 +28,7 @@ class AccountController @Inject() (proxyConnector: HelpToSaveProxyConnector,
   extends HelpToSaveAuth(authConnector) with WithMdcExecutionContext with AccountQuery {
 
   def getAccount(nino: String, systemId: String, correlationId: Option[String]): Action[AnyContent] =
-    accountQuery(nino, systemId, correlationId) { implicit request ⇒ (nino, systemId, id) ⇒
-      proxyConnector.getAccount(nino, systemId, id)
+    accountQuery(nino, systemId, correlationId) { implicit request ⇒ nsiParams ⇒
+      proxyConnector.getAccount(nsiParams.nino, nsiParams.systemId, nsiParams.correlationId)
     }
 }

--- a/app/uk/gov/hmrc/helptosave/controllers/AccountQuery.scala
+++ b/app/uk/gov/hmrc/helptosave/controllers/AccountQuery.scala
@@ -24,15 +24,17 @@ import cats.syntax.eq._
 import play.api.libs.json.{Json, Writes}
 import play.api.mvc._
 import uk.gov.hmrc.helptosave.util
-import uk.gov.hmrc.helptosave.util.{LogMessageTransformer, Logging}
 import uk.gov.hmrc.helptosave.util.Logging._
+import uk.gov.hmrc.helptosave.util.{LogMessageTransformer, Logging}
+
+case class NsiAccountQueryParams(nino: String, systemId: String, correlationId: String)
 
 trait AccountQuery extends Logging with Results { this: HelpToSaveAuth ⇒
 
   /**
    * Behaviour common to actions that query for Help to Save account data based on NINO
    */
-  protected def accountQuery[A](nino: String, systemId: String, correlationId: Option[String])(query: Request[AnyContent] ⇒ (String, String, String) ⇒ util.Result[Option[A]])(implicit transformer: LogMessageTransformer, writes: Writes[A]): Action[AnyContent] = authorised { implicit request ⇒ implicit authNino ⇒
+  protected def accountQuery[A](nino: String, systemId: String, correlationId: Option[String])(query: Request[AnyContent] ⇒ NsiAccountQueryParams ⇒ util.Result[Option[A]])(implicit transformer: LogMessageTransformer, writes: Writes[A]): Action[AnyContent] = authorised { implicit request ⇒ implicit authNino ⇒
     if (!uk.gov.hmrc.domain.Nino.isValid(nino)) {
       logger.warn("NINO in request was not valid")
       BadRequest
@@ -41,7 +43,7 @@ trait AccountQuery extends Logging with Results { this: HelpToSaveAuth ⇒
       Forbidden
     } else {
       val id = correlationId.getOrElse(UUID.randomUUID().toString)
-      query(request)(nino, systemId, id)
+      query(request)(NsiAccountQueryParams(nino, systemId, id))
         .fold(
           { errorString ⇒
             logger.warn(errorString, nino, "correlationId" → id)

--- a/app/uk/gov/hmrc/helptosave/controllers/AccountQuery.scala
+++ b/app/uk/gov/hmrc/helptosave/controllers/AccountQuery.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.controllers
+
+import java.util.UUID
+
+import cats.instances.future._
+import cats.instances.string._
+import cats.syntax.eq._
+import play.api.libs.json.{Json, Writes}
+import play.api.mvc._
+import uk.gov.hmrc.helptosave.util
+import uk.gov.hmrc.helptosave.util.{LogMessageTransformer, Logging}
+import uk.gov.hmrc.helptosave.util.Logging._
+
+trait AccountQuery extends Logging with Results { this: HelpToSaveAuth ⇒
+
+  /**
+   * Behaviour common to actions that query for Help to Save account data based on NINO
+   */
+  protected def accountQuery[A](nino: String, systemId: String, correlationId: Option[String])(query: Request[AnyContent] ⇒ (String, String, String) ⇒ util.Result[Option[A]])(implicit transformer: LogMessageTransformer, writes: Writes[A]): Action[AnyContent] = authorised { implicit request ⇒ implicit authNino ⇒
+    if (!uk.gov.hmrc.domain.Nino.isValid(nino)) {
+      logger.warn("NINO in request was not valid")
+      BadRequest
+    } else if (nino =!= authNino) {
+      logger.warn("NINO in request did not match NINO found in auth")
+      Forbidden
+    } else {
+      val id = correlationId.getOrElse(UUID.randomUUID().toString)
+      query(request)(nino, systemId, id)
+        .fold(
+          { errorString ⇒
+            logger.warn(errorString, nino, "correlationId" → id)
+            InternalServerError
+          },
+          _.fold[Result](NotFound)(found ⇒ Ok(Json.toJson(found)))
+        )
+    }
+  }
+}

--- a/app/uk/gov/hmrc/helptosave/controllers/TransactionsController.scala
+++ b/app/uk/gov/hmrc/helptosave/controllers/TransactionsController.scala
@@ -23,12 +23,12 @@ import uk.gov.hmrc.helptosave.config.AppConfig
 import uk.gov.hmrc.helptosave.connectors.HelpToSaveProxyConnector
 import uk.gov.hmrc.helptosave.util.{LogMessageTransformer, WithMdcExecutionContext}
 
-class AccountController @Inject() (proxyConnector: HelpToSaveProxyConnector,
-                                   authConnector:  AuthConnector)(implicit transformer: LogMessageTransformer, appConfig: AppConfig)
+class TransactionsController @Inject() (proxyConnector: HelpToSaveProxyConnector,
+                                        authConnector:  AuthConnector)(implicit transformer: LogMessageTransformer, appConfig: AppConfig)
   extends HelpToSaveAuth(authConnector) with WithMdcExecutionContext with AccountQuery {
 
-  def getAccount(nino: String, systemId: String, correlationId: Option[String]): Action[AnyContent] =
+  def getTransactions(nino: String, systemId: String, correlationId: Option[String]): Action[AnyContent] =
     accountQuery(nino, systemId, correlationId) { implicit request ⇒ (nino, systemId, id) ⇒
-      proxyConnector.getAccount(nino, systemId, id)
+      proxyConnector.getTransactions(nino, systemId, id)
     }
 }

--- a/app/uk/gov/hmrc/helptosave/controllers/TransactionsController.scala
+++ b/app/uk/gov/hmrc/helptosave/controllers/TransactionsController.scala
@@ -28,7 +28,7 @@ class TransactionsController @Inject() (proxyConnector: HelpToSaveProxyConnector
   extends HelpToSaveAuth(authConnector) with WithMdcExecutionContext with AccountQuery {
 
   def getTransactions(nino: String, systemId: String, correlationId: Option[String]): Action[AnyContent] =
-    accountQuery(nino, systemId, correlationId) { implicit request ⇒ (nino, systemId, id) ⇒
-      proxyConnector.getTransactions(nino, systemId, id)
+    accountQuery(nino, systemId, correlationId) { implicit request ⇒ nsiParams ⇒
+      proxyConnector.getTransactions(nsiParams.nino, nsiParams.systemId, nsiParams.correlationId)
     }
 }

--- a/app/uk/gov/hmrc/helptosave/metrics/Metrics.scala
+++ b/app/uk/gov/hmrc/helptosave/metrics/Metrics.scala
@@ -59,5 +59,9 @@ class Metrics @Inject() (metrics: com.kenshoo.play.metrics.Metrics) {
   val getAccountTimer: Timer = timer("backend.get-account.time")
 
   val getAccountErrorCounter: Counter = counter("backend.get-account-error.count")
+
+  val getTransactionsTimer: Timer = timer("backend.get-transactions.time")
+
+  val getTransactionsErrorCounter: Counter = counter("backend.get-transactions-error.count")
 }
 

--- a/app/uk/gov/hmrc/helptosave/models/account/NsiTransactions.scala
+++ b/app/uk/gov/hmrc/helptosave/models/account/NsiTransactions.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.models.account
+
+import java.time.LocalDate
+
+import play.api.libs.json.{Json, Reads}
+
+case class NsiTransaction(
+    sequence:             String,
+    operation:            String,
+    amount:               BigDecimal,
+    transactionDate:      LocalDate,
+    accountingDate:       LocalDate,
+    description:          String,
+    transactionReference: String
+)
+
+object NsiTransaction {
+  implicit val reads: Reads[NsiTransaction] = Json.reads[NsiTransaction]
+}
+
+case class NsiTransactions(transactions: Seq[NsiTransaction])
+
+object NsiTransactions {
+  implicit val reads: Reads[NsiTransactions] = Json.reads[NsiTransactions]
+}

--- a/app/uk/gov/hmrc/helptosave/models/account/Transactions.scala
+++ b/app/uk/gov/hmrc/helptosave/models/account/Transactions.scala
@@ -42,7 +42,7 @@ object Operation {
   }
 }
 
-case class ValidNsiTransaction(
+private case class ValidNsiTransaction(
     sequence:             Int,
     operation:            Operation,
     amount:               BigDecimal,
@@ -52,7 +52,7 @@ case class ValidNsiTransaction(
     transactionReference: String
 )
 
-object ValidNsiTransaction {
+private object ValidNsiTransaction {
   private type ValidOrErrorString[A] = ValidatedNel[String, A]
 
   def apply(nsiTransaction: NsiTransaction): ValidatedNel[String, ValidNsiTransaction] = {

--- a/app/uk/gov/hmrc/helptosave/models/account/Transactions.scala
+++ b/app/uk/gov/hmrc/helptosave/models/account/Transactions.scala
@@ -119,7 +119,7 @@ object Transactions {
       .map(sortLikeNsiWeb _ andThen runningBalance andThen Transactions.apply)
   }
 
-  private implicit val eqLocalDate: Eq[LocalDate] = Eq.fromUniversalEquals
+  private implicit val eqLocalDate: Eq[LocalDate] = Eq.instance(_.isEqual(_))
 
   private def sortLikeNsiWeb(transactions: Seq[ValidNsiTransaction]): Seq[ValidNsiTransaction] = {
     transactions.sortWith { (t1, t2) ⇒

--- a/app/uk/gov/hmrc/helptosave/models/account/Transactions.scala
+++ b/app/uk/gov/hmrc/helptosave/models/account/Transactions.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.models.account
+
+import java.time.LocalDate
+
+import cats.Eq
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.{NonEmptyList, ValidatedNel}
+import cats.instances.list._
+import cats.instances.string._
+import cats.syntax.apply._
+import cats.syntax.eq._
+import cats.syntax.traverse._
+import play.api.libs.json.{JsString, JsValue, Json, Writes}
+
+sealed trait Operation
+case object Credit extends Operation
+case object Debit extends Operation
+
+object Operation {
+  implicit val eqOperation: Eq[Operation] = Eq.fromUniversalEquals
+  implicit val writes: Writes[Operation] = new Writes[Operation] {
+    override def writes(o: Operation): JsValue = JsString(o match {
+      case Credit ⇒ "credit"
+      case Debit  ⇒ "debit"
+    })
+  }
+}
+
+case class ValidNsiTransaction(
+    sequence:             Int,
+    operation:            Operation,
+    amount:               BigDecimal,
+    transactionDate:      LocalDate,
+    accountingDate:       LocalDate,
+    description:          String,
+    transactionReference: String
+)
+
+object ValidNsiTransaction {
+  private type ValidOrErrorString[A] = ValidatedNel[String, A]
+
+  def apply(nsiTransaction: NsiTransaction): ValidatedNel[String, ValidNsiTransaction] = {
+      def operationValidation(nsiOperation: String): ValidOrErrorString[Operation] =
+        if (nsiOperation === "C") { Valid(Credit) }
+        else if (nsiOperation === "D") { Valid(Debit) }
+        else { Invalid(NonEmptyList.one(s"""Unknown value for operation: "$nsiOperation"""")) }
+
+      def sequenceValidation(nsiSequence: String): ValidOrErrorString[Int] =
+        try Valid(nsiSequence.toInt)
+        catch {
+          case _: NumberFormatException ⇒ Invalid(NonEmptyList.one(s"""Can't parse sequence value as an integer: "$nsiSequence""""))
+        }
+
+    (operationValidation(nsiTransaction.operation), sequenceValidation(nsiTransaction.sequence)).mapN {
+      case (operation, sequence) ⇒
+        ValidNsiTransaction(
+          sequence,
+          operation,
+          nsiTransaction.amount,
+          nsiTransaction.transactionDate,
+          nsiTransaction.accountingDate,
+          nsiTransaction.description,
+          nsiTransaction.transactionReference
+        )
+    }
+  }
+}
+
+case class Transaction(
+    operation:            Operation,
+    amount:               BigDecimal,
+    transactionDate:      LocalDate,
+    accountingDate:       LocalDate,
+    description:          String,
+    transactionReference: String,
+    balanceAfter:         BigDecimal
+)
+
+object Transaction {
+  implicit val writes: Writes[Transaction] = Json.writes[Transaction]
+
+  def apply(vnt: ValidNsiTransaction, balanceAfter: BigDecimal): Transaction = Transaction(
+    vnt.operation,
+    vnt.amount,
+    vnt.transactionDate,
+    vnt.accountingDate,
+    vnt.description,
+    vnt.transactionReference,
+    balanceAfter
+  )
+}
+
+case class Transactions(transactions: Seq[Transaction])
+
+object Transactions {
+  implicit val writes: Writes[Transactions] = Json.writes[Transactions]
+
+  private type ValidOrErrorString[A] = ValidatedNel[String, A]
+
+  def apply(nsiTransactions: NsiTransactions): ValidatedNel[String, Transactions] = {
+    nsiTransactions.transactions.toList
+      .traverse[ValidOrErrorString, ValidNsiTransaction](ValidNsiTransaction.apply)
+      .map(sortLikeNsiWeb)
+      .map(runningBalance)
+      .map(Transactions.apply)
+  }
+
+  private implicit val eqLocalDate: Eq[LocalDate] = Eq.fromUniversalEquals
+
+  private def sortLikeNsiWeb(transactions: Seq[ValidNsiTransaction]): Seq[ValidNsiTransaction] = {
+    transactions.sortWith { (t1, t2) ⇒
+      if (t1.accountingDate === t2.accountingDate) {
+        t1.sequence < t2.sequence
+      } else {
+        t1.accountingDate.isBefore(t2.accountingDate)
+      }
+    }
+  }
+
+  private def runningBalance(transactions: Seq[ValidNsiTransaction]): Seq[Transaction] = {
+    transactions.foldLeft((Vector.empty[Transaction], 0: BigDecimal)){ (acc, vnt: ValidNsiTransaction) ⇒
+      val (accTransactions, accBalance) = acc
+
+      val newBalance = if (vnt.operation === Credit) {
+        accBalance + vnt.amount
+      } else {
+        accBalance - vnt.amount
+      }
+
+      val newT = Transaction(vnt, newBalance)
+
+      (accTransactions :+ newT, newBalance)
+    }._1
+  }
+}

--- a/app/uk/gov/hmrc/helptosave/models/account/Transactions.scala
+++ b/app/uk/gov/hmrc/helptosave/models/account/Transactions.scala
@@ -116,9 +116,7 @@ object Transactions {
   def apply(nsiTransactions: NsiTransactions): ValidatedNel[String, Transactions] = {
     nsiTransactions.transactions.toList
       .traverse[ValidOrErrorString, ValidNsiTransaction](ValidNsiTransaction.apply)
-      .map(sortLikeNsiWeb)
-      .map(runningBalance)
-      .map(Transactions.apply)
+      .map(sortLikeNsiWeb _ andThen runningBalance andThen Transactions.apply)
   }
 
   private implicit val eqLocalDate: Eq[LocalDate] = Eq.fromUniversalEquals

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ val dependencies = Seq(
   "uk.gov.hmrc" %% "domain" % "5.1.0",
   "org.typelevel" %% "cats-core" % "1.1.0",
   "com.github.kxbmap" %% "configs" % "0.4.4",
+  "io.lemonlabs" %% "scala-uri" % "1.1.1",
   "uk.gov.hmrc" %% "play-reactivemongo" % "6.2.0",
   "uk.gov.hmrc" %% "crypto" % "4.5.0",
   "uk.gov.hmrc" %% "bootstrap-play-25" % "1.4.0"
@@ -101,11 +102,14 @@ lazy val wartRemoverSettings = {
   wartremoverErrors in(Compile, compile) ++= Warts.allBut(excludedWarts: _*)
 }
 
+lazy val catsSettings = scalacOptions += "-Ypartial-unification"
+
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin) ++ plugins: _*)
   .settings(addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.17"))
   .settings(playSettings ++ scoverageSettings: _*)
   .settings(scalaSettings: _*)
+  .settings(scalaVersion := "2.11.12")
   .settings(publishingSettings: _*)
   .settings(defaultSettings(): _*)
   .settings(scalariformSettings: _*)
@@ -122,6 +126,7 @@ lazy val microservice = Project(appName, file("."))
       (baseDirectory.value ** "UCThresholdConnectorProxyActor.scala").get ++
       (baseDirectory.value ** "UCThresholdMongoProxy.scala").get
   )
+  .settings(catsSettings)
   .settings(
     libraryDependencies ++= appDependencies,
     retrieveManaged := false,

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,17 +1,18 @@
 # microservice specific routes
 
-GET  /eligibility-check       @uk.gov.hmrc.helptosave.controllers.EligibilityCheckController.eligibilityCheck()
-GET  /enrolment-status        @uk.gov.hmrc.helptosave.controllers.EnrolmentStoreController.getEnrolmentStatus()
-GET  /enrol-user              @uk.gov.hmrc.helptosave.controllers.EnrolmentStoreController.enrol()
-GET  /set-itmp-flag           @uk.gov.hmrc.helptosave.controllers.EnrolmentStoreController.setITMPFlag()
-GET  /store-email             @uk.gov.hmrc.helptosave.controllers.EmailStoreController.store(email: String)
-GET  /get-email               @uk.gov.hmrc.helptosave.controllers.EmailStoreController.get()
-GET  /account-create-allowed  @uk.gov.hmrc.helptosave.controllers.UserCapController.isAccountCreateAllowed()
-POST /update-user-count       @uk.gov.hmrc.helptosave.controllers.UserCapController.update()
-GET  /:nino/account           @uk.gov.hmrc.helptosave.controllers.AccountController.getAccount(nino: String, systemId: String, correlationId: Option[String])
+GET  /eligibility-check           @uk.gov.hmrc.helptosave.controllers.EligibilityCheckController.eligibilityCheck()
+GET  /enrolment-status            @uk.gov.hmrc.helptosave.controllers.EnrolmentStoreController.getEnrolmentStatus()
+GET  /enrol-user                  @uk.gov.hmrc.helptosave.controllers.EnrolmentStoreController.enrol()
+GET  /set-itmp-flag               @uk.gov.hmrc.helptosave.controllers.EnrolmentStoreController.setITMPFlag()
+GET  /store-email                 @uk.gov.hmrc.helptosave.controllers.EmailStoreController.store(email: String)
+GET  /get-email                   @uk.gov.hmrc.helptosave.controllers.EmailStoreController.get()
+GET  /account-create-allowed      @uk.gov.hmrc.helptosave.controllers.UserCapController.isAccountCreateAllowed()
+POST /update-user-count           @uk.gov.hmrc.helptosave.controllers.UserCapController.update()
+GET  /:nino/account               @uk.gov.hmrc.helptosave.controllers.AccountController.getAccount(nino: String, systemId: String, correlationId: Option[String])
+GET  /:nino/account/transactions  @uk.gov.hmrc.helptosave.controllers.TransactionsController.getTransactions(nino: String, systemId: String, correlationId: Option[String])
 
-POST /create-de-account            @uk.gov.hmrc.helptosave.controllers.HelpToSaveNonDigitalController.createDEAccount()
-GET  /api/eligibility-check/:nino  @uk.gov.hmrc.helptosave.controllers.HelpToSaveNonDigitalController.checkEligibility(nino: String)
+POST /create-de-account           @uk.gov.hmrc.helptosave.controllers.HelpToSaveNonDigitalController.createDEAccount()
+GET  /api/eligibility-check/:nino @uk.gov.hmrc.helptosave.controllers.HelpToSaveNonDigitalController.checkEligibility(nino: String)
 
 
 GET /stride/enrolment-status      @uk.gov.hmrc.helptosave.controllers.StrideController.getEnrolmentStatus(nino: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -211,9 +211,14 @@ stride.base64-encoded-roles = [
   "aHRzIGhlbHBkZXNrIGFkdmlzb3I=" # "hts helpdesk advisor"
 ]
 
-nsi.get-account {
-  version                     = "V1.0"
+nsi {
   no-account-error-message-id = "HTS-API015-006"
+  get-account {
+    version = "V1.0"
+  }
+  get-transactions {
+    version = "V1.0"
+  }
 }
 
 

--- a/test/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnectorSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.EitherValues
 import play.api.libs.json.{Json, Writes}
 import play.mvc.Http.Status.{BAD_REQUEST, CREATED, INTERNAL_SERVER_ERROR, OK}
 import uk.gov.hmrc.helptosave.models.NSIUserInfo.ContactDetails
-import uk.gov.hmrc.helptosave.models.account.{Account, Blocking, BonusTerm}
+import uk.gov.hmrc.helptosave.models.account._
 import uk.gov.hmrc.helptosave.models.{NSIUserInfo, UCResponse}
 import uk.gov.hmrc.helptosave.util.toFuture
 import uk.gov.hmrc.helptosave.utils.{MockPagerDuty, TestSupport}
@@ -72,6 +72,11 @@ class HelpToSaveProxyConnectorSpec extends TestSupport with MockPagerDuty with E
     (mockHttp.get(_: String, _: Map[String, String])(_: HeaderCarrier, _: ExecutionContext))
       .expects(url, Map.empty[String, String], *, *)
       .returning(response.fold(Future.failed[HttpResponse](new Exception("")))(Future.successful))
+
+  private def mockGetTransactionsResponse(url: String)(response: Option[HttpResponse]) =
+    (mockHttp.get(_: String, _: Map[String, String])(_: HeaderCarrier, _: ExecutionContext))
+      .expects(url, Map.empty[String, String], *, *)
+      .returning(response.fold(Future.failed[HttpResponse](new Exception("Test exception message")))(Future.successful))
 
   "The HelpToSaveProxyConnector" when {
     "creating account" must {
@@ -320,7 +325,7 @@ class HelpToSaveProxyConnectorSpec extends TestSupport with MockPagerDuty with E
               |      "errorDetail"    : "detail"
               |    },
               |    {
-              |      "errorMessageId" : "${appConfig.runModeConfiguration.underlying.getString("nsi.get-account.no-account-error-message-id")}",
+              |      "errorMessageId" : "${appConfig.runModeConfiguration.underlying.getString("nsi.no-account-error-message-id")}",
               |      "errorMessage"   : "Oh no!",
               |      "errorDetail"    : "Account doesn't exist"
               |    }
@@ -332,9 +337,245 @@ class HelpToSaveProxyConnectorSpec extends TestSupport with MockPagerDuty with E
 
         val result = await(proxyConnector.getAccount(nino, systemId, correlationId).value)
         result shouldBe Right(None)
-
       }
 
+      "handle characters in correlationId and systemId that need to be escaped" in {
+        val needsEscapingCorrelationId = "a&b"
+        val needsEscapingSystemId = "system<>&id"
+        val queryString = s"nino=$nino&correlationId=${java.net.URLEncoder.encode(needsEscapingCorrelationId, "UTF-8")}&version=$version" +
+          s"&systemId=${java.net.URLEncoder.encode(needsEscapingSystemId, "UTF-8")}"
+
+        val needsEscapingGetAccountUrl: String = s"http://localhost:7005/help-to-save-proxy/nsi-services/account?$queryString"
+
+        val json = Json.parse(
+          """
+            |{
+            |  "accountBalance": "200.34",
+            |  "accountClosedFlag": "",
+            |  "accountBlockingCode": "00",
+            |  "clientBlockingCode": "00",
+            |  "currentInvestmentMonth": {
+            |    "investmentRemaining": "15.50",
+            |    "investmentLimit": "50.00",
+            |    "endDate": "2018-02-28"
+            |  },
+            |  "terms": []
+            |}
+          """.stripMargin)
+
+        mockGetAccountResponse(needsEscapingGetAccountUrl)(Some(HttpResponse(200, Some(json))))
+
+        val result = await(proxyConnector.getAccount(nino, needsEscapingSystemId, needsEscapingCorrelationId).value)
+
+        result shouldBe Right(Some(Account(
+          isClosed = false,
+          Blocking(false),
+          200.34,
+          34.50,
+          15.50,
+          50.00,
+          LocalDate.parse("2018-02-28"),
+          List(),
+          None,
+          None)
+        ))
+      }
+
+    }
+
+    "retrieving transactions" must {
+      val nino = randomNINO()
+      val correlationId = UUID.randomUUID().toString
+      val systemId = "123"
+      val version = appConfig.runModeConfiguration.underlying.getString("nsi.get-transactions.version")
+
+      val queryString = s"nino=$nino&correlationId=$correlationId&version=$version&systemId=$systemId"
+
+      val getTransactionsUrl: String = s"http://localhost:7005/help-to-save-proxy/nsi-services/transactions?$queryString"
+
+        def transactionMetricChanges[T](body: ⇒ T): (T, Long, Long) = {
+          val timerCountBefore = mockMetrics.getTransactionsTimer.getCount
+          val errorCountBefore = mockMetrics.getTransactionsErrorCounter.getCount
+          val result = body
+          (result, mockMetrics.getTransactionsTimer.getCount - timerCountBefore, mockMetrics.getTransactionsErrorCounter.getCount - errorCountBefore)
+        }
+
+      "handle success response by translating transactions from NS&I domain into MDTP domain" in {
+        val json = Json.parse(
+          """{
+            |  "transactions": [
+            |    {
+            |      "sequence": "1",
+            |      "amount": "11.50",
+            |      "operation": "C",
+            |      "description": "Debit card online deposit",
+            |      "transactionReference": "A1A11AA1A00A0034",
+            |      "transactionDate": "2017-11-20",
+            |      "accountingDate": "2017-11-20"
+            |    },
+            |    {
+            |      "sequence": "2",
+            |      "amount": "1.01",
+            |      "operation": "D",
+            |      "description": "BACS payment",
+            |      "transactionReference": "A1A11AA1A00A000I",
+            |      "transactionDate": "2017-11-27",
+            |      "accountingDate": "2017-11-27"
+            |    },
+            |    {
+            |      "sequence": "3",
+            |      "amount": "1.11",
+            |      "operation": "D",
+            |      "description": "BACS payment",
+            |      "transactionReference": "A1A11AA1A00A000G",
+            |      "transactionDate": "2017-11-27",
+            |      "accountingDate": "2017-11-27"
+            |    },
+            |    {
+            |      "sequence": "4",
+            |      "amount": "1.11",
+            |      "operation": "C",
+            |      "description": "Reinstatement Adjustment",
+            |      "transactionReference": "A1A11AA1A00A000G",
+            |      "transactionDate": "2017-11-27",
+            |      "accountingDate": "2017-12-04"
+            |    },
+            |    {
+            |      "sequence": "1",
+            |      "amount": "50.00",
+            |      "operation": "C",
+            |      "description": "Debit card online deposit",
+            |      "transactionReference": "A1A11AA1A00A0059",
+            |      "transactionDate": "2018-04-10",
+            |      "accountingDate": "2018-04-10"
+            |    }
+            |  ]
+            |}
+            |""".stripMargin
+        )
+
+        mockGetTransactionsResponse(getTransactionsUrl)(Some(HttpResponse(200, Some(json))))
+
+        val (result, timerMetricChange, errorMetricChange) = transactionMetricChanges(await(proxyConnector.getTransactions(nino, systemId, correlationId).value))
+
+        result shouldBe Right(Some(Transactions(Seq(
+          Transaction(Credit, BigDecimal("11.50"), LocalDate.parse("2017-11-20"), LocalDate.parse("2017-11-20"), "Debit card online deposit", "A1A11AA1A00A0034", BigDecimal("11.50")),
+          Transaction(Debit, BigDecimal("1.01"), LocalDate.parse("2017-11-27"), LocalDate.parse("2017-11-27"), "BACS payment", "A1A11AA1A00A000I", BigDecimal("10.49")),
+          Transaction(Debit, BigDecimal("1.11"), LocalDate.parse("2017-11-27"), LocalDate.parse("2017-11-27"), "BACS payment", "A1A11AA1A00A000G", BigDecimal("9.38")),
+          Transaction(Credit, BigDecimal("1.11"), LocalDate.parse("2017-11-27"), LocalDate.parse("2017-12-04"), "Reinstatement Adjustment", "A1A11AA1A00A000G", BigDecimal("10.49")),
+          Transaction(Credit, BigDecimal(50), LocalDate.parse("2018-04-10"), LocalDate.parse("2018-04-10"), "Debit card online deposit", "A1A11AA1A00A0059", BigDecimal("60.49"))
+        ))))
+        timerMetricChange shouldBe 1
+        errorMetricChange shouldBe 0
+      }
+
+      "return an error when the GET transaction JSON is missing fields that are required according to get_transactions_by_nino_RESP_schema_V1.0.json" in {
+        val json = Json.parse(
+          // invalid because sequence is missing from first transaction
+          """{
+            |  "transactions": [
+            |    {
+            |      "amount": "11.50",
+            |      "operation": "C",
+            |      "description": "Debit card online deposit",
+            |      "transactionReference": "A1A11AA1A00A0034",
+            |      "transactionDate": "2017-11-20",
+            |      "accountingDate": "2017-11-20"
+            |    }
+            |  ]
+            |}
+            |""".stripMargin
+        )
+
+        mockGetTransactionsResponse(getTransactionsUrl)(Some(HttpResponse(200, Some(json))))
+        mockPagerDutyAlert("Could not parse JSON in the get transactions response")
+
+        val (result, timerMetricChange, errorMetricChange) = transactionMetricChanges(await(proxyConnector.getTransactions(nino, systemId, correlationId).value))
+
+        result shouldBe Left("Could not parse transactions response from NS&I, received 200 (OK), error=Could not parse http response JSON: /transactions(0)/sequence: [error.path.missing]")
+        timerMetricChange shouldBe 1
+        errorMetricChange shouldBe 1
+      }
+
+      "handle non 200 responses from help-to-save-proxy" in {
+        mockGetTransactionsResponse(getTransactionsUrl)(Some(HttpResponse(400)))
+        mockPagerDutyAlert("Received unexpected http status in response to get transactions")
+
+        val (result, timerMetricChange, errorMetricChange) = transactionMetricChanges(await(proxyConnector.getTransactions(nino, systemId, correlationId).value))
+        result shouldBe Left("Received unexpected status(400) from get transactions call")
+        timerMetricChange shouldBe 1
+        errorMetricChange shouldBe 1
+      }
+
+      "handle unexpected server errors" in {
+        mockGetTransactionsResponse(getTransactionsUrl)(None)
+        mockPagerDutyAlert("Failed to make call to get transactions")
+
+        val (result, timerMetricChange, errorMetricChange) = transactionMetricChanges(await(proxyConnector.getTransactions(nino, systemId, correlationId).value))
+        result shouldBe Left("Call to get transactions unsuccessful: Test exception message")
+        timerMetricChange shouldBe 1
+        errorMetricChange shouldBe 1
+      }
+
+      "handle the case where an account does not exist by returning Right(None)" in {
+        val errorResponse =
+          Json.parse(
+            s"""
+              |{
+              |  "errors" : [
+              |    {
+              |      "errorMessageId" : "id",
+              |      "errorMessage"   : "message",
+              |      "errorDetail"    : "detail"
+              |    },
+              |    {
+              |      "errorMessageId" : "${appConfig.runModeConfiguration.underlying.getString("nsi.no-account-error-message-id")}",
+              |      "errorMessage"   : "Oh no!",
+              |      "errorDetail"    : "Account doesn't exist"
+              |    }
+              |  ]
+              |}
+          """.stripMargin)
+
+        mockGetTransactionsResponse(getTransactionsUrl)(Some(HttpResponse(400, Some(errorResponse))))
+
+        val result = await(proxyConnector.getTransactions(nino, systemId, correlationId).value)
+        result shouldBe Right(None)
+      }
+
+      "handle characters in correlationId and systemId that need to be escaped" in {
+        val needsEscapingCorrelationId = "a&b"
+        val needsEscapingSystemId = "system<>&id"
+        val queryString = s"nino=$nino&correlationId=${java.net.URLEncoder.encode(needsEscapingCorrelationId, "UTF-8")}&version=$version" +
+          s"&systemId=${java.net.URLEncoder.encode(needsEscapingSystemId, "UTF-8")}"
+
+        val needsEscapingGetTransactionsUrl: String = s"http://localhost:7005/help-to-save-proxy/nsi-services/transactions?$queryString"
+
+        val json = Json.parse(
+          """{
+            |  "transactions": [
+            |    {
+            |      "sequence": "1",
+            |      "amount": "11.50",
+            |      "operation": "C",
+            |      "description": "Debit card online deposit",
+            |      "transactionReference": "A1A11AA1A00A0034",
+            |      "transactionDate": "2017-11-20",
+            |      "accountingDate": "2017-11-20"
+            |    }
+            |  ]
+            |}
+            |""".stripMargin
+        )
+
+        mockGetTransactionsResponse(needsEscapingGetTransactionsUrl)(Some(HttpResponse(200, Some(json))))
+
+        val result = await(proxyConnector.getTransactions(nino, needsEscapingSystemId, needsEscapingCorrelationId).value)
+
+        result shouldBe Right(Some(Transactions(Seq(
+          Transaction(Credit, BigDecimal("11.50"), LocalDate.parse("2017-11-20"), LocalDate.parse("2017-11-20"), "Debit card online deposit", "A1A11AA1A00A0034", BigDecimal("11.50"))
+        ))))
+      }
     }
   }
 }

--- a/test/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnectorSpec.scala
@@ -492,7 +492,7 @@ class HelpToSaveProxyConnectorSpec extends TestSupport with MockPagerDuty with E
 
         val (result, timerMetricChange, errorMetricChange) = transactionMetricChanges(await(proxyConnector.getTransactions(nino, systemId, correlationId).value))
 
-        result shouldBe Left("Could not parse transactions response from NS&I, received 200 (OK), error=Could not parse http response JSON: /transactions(0)/sequence: [error.path.missing]")
+        result shouldBe Left("Could not parse transactions response from NS&I, received 200 (OK), error=[Could not parse http response JSON: /transactions(0)/sequence: [error.path.missing]]")
         timerMetricChange shouldBe 1
         errorMetricChange shouldBe 1
       }

--- a/test/uk/gov/hmrc/helptosave/controllers/TransactionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/controllers/TransactionsControllerSpec.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.controllers
+
+import java.time.LocalDate
+import java.util.UUID
+
+import cats.data.EitherT
+import cats.instances.future._
+import org.scalamock.function.MockFunction5
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{contentAsJson, _}
+import uk.gov.hmrc.helptosave.connectors.HelpToSaveProxyConnector
+import uk.gov.hmrc.helptosave.controllers.HelpToSaveAuth.AuthWithCL200
+import uk.gov.hmrc.helptosave.models.account._
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class TransactionsControllerSpec extends AuthSupport {
+
+  val mockProxyConnector: HelpToSaveProxyConnector = mock[HelpToSaveProxyConnector]
+
+  val controller = new TransactionsController(mockProxyConnector, mockAuthConnector)
+
+  val transactions = Transactions(Seq(
+    Transaction(
+      operation            = Credit,
+      amount               = BigDecimal("1.23"),
+      transactionDate      = LocalDate.parse("2018-06-08"),
+      accountingDate       = LocalDate.parse("2018-06-08"),
+      description          = "Debit card online deposit",
+      transactionReference = "A1A11AA1A00A0034",
+      balanceAfter         = BigDecimal("1.23"))
+  ))
+
+  val queryString = s"nino=$nino&correlationId=${UUID.randomUUID()}&systemId=123"
+
+  val fakeRequest = FakeRequest("GET", s"/nsi-account?$queryString")
+
+  def mockGetTransactions(nino: String, systemId: String, correlationId: Option[String])(response: Either[String, Option[Transactions]]): Unit = {
+    val call: MockFunction5[String, String, String, HeaderCarrier, ExecutionContext, EitherT[Future, String, Option[Transactions]]] =
+      mockProxyConnector.getTransactions(_: String, _: String, _: String)(_: HeaderCarrier, _: ExecutionContext)
+
+    val callHandler = correlationId.fold(
+      call.expects(nino, systemId, *, *, *)
+    ){ id ⇒
+        call.expects(nino, systemId, id, *, *)
+      }
+
+    callHandler.returning(EitherT.fromEither(response))
+  }
+
+  "The TransactionsController" when {
+
+    "retrieving getTransactions for an user" must {
+
+      val systemId = "system"
+
+      "handle success responses" in {
+        inSequence {
+          mockAuthResultWithSuccess(AuthWithCL200)(mockedNinoRetrieval)
+          mockGetTransactions(nino, systemId, None)(Right(Some(transactions)))
+        }
+
+        val result = controller.getTransactions(nino, systemId, None)(fakeRequest)
+        status(result) shouldBe 200
+        contentAsJson(result) shouldBe Json.toJson(Some(transactions))
+      }
+
+      "return a 403 (FORBIDDEN) if the NINO in the URL doesn't match the NINO retrieved from auth" in {
+        mockAuthResultWithSuccess(AuthWithCL200)(mockedNinoRetrieval)
+
+        val result = controller.getTransactions("BE123456C", systemId, None)(fakeRequest)
+        status(result) shouldBe 403
+      }
+
+      "return a 404 if an transactions does not exist for the NINO" in {
+        inSequence {
+          mockAuthResultWithSuccess(AuthWithCL200)(mockedNinoRetrieval)
+          mockGetTransactions(nino, systemId, None)(Right(None))
+        }
+
+        val result = controller.getTransactions(nino, systemId, None)(fakeRequest)
+        status(result) shouldBe 404
+      }
+
+      "return a 400 if the NINO is not valid" in {
+        mockAuthResultWithSuccess(AuthWithCL200)(mockedNinoRetrieval)
+
+        val result = controller.getTransactions("nino", systemId, None)(fakeRequest)
+        status(result) shouldBe 400
+      }
+
+      "handle errors returned by the connector" in {
+        inSequence {
+          mockAuthResultWithSuccess(AuthWithCL200)(mockedNinoRetrieval)
+          mockGetTransactions(nino, systemId, None)(Left("some error"))
+        }
+
+        val result = controller.getTransactions(nino, systemId, None)(fakeRequest)
+        status(result) shouldBe 500
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/helptosave/models/account/OperationJsonSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/models/account/OperationJsonSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.models.account
+
+import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.{JsString, Writes}
+
+class OperationJsonSpec extends WordSpec with Matchers {
+  "JSON for Operation" should {
+    """be a "credit" or "debit" String """ in {
+      val writes = implicitly[Writes[Operation]]
+      writes.writes(Credit) shouldBe JsString("credit")
+      writes.writes(Debit) shouldBe JsString("debit")
+    }
+  }
+}

--- a/test/uk/gov/hmrc/helptosave/models/account/TransactionsSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/models/account/TransactionsSpec.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.models.account
+
+import java.time.LocalDate
+
+import cats.data.NonEmptyList
+import cats.data.Validated.{Invalid, Valid}
+import uk.gov.hmrc.helptosave.utils.TestSupport
+
+class TransactionsSpec extends TestSupport {
+
+  private val nsiCreditTransaction = NsiTransaction(
+    sequence             = "1",
+    amount               = BigDecimal("1.23"),
+    operation            = "C",
+    description          = "description",
+    transactionReference = "reference",
+    transactionDate      = LocalDate.parse("1900-01-01"),
+    accountingDate       = LocalDate.parse("1900-01-02")
+  )
+  private val validNsiCreditTransaction = ValidNsiTransaction(
+    1,
+    Credit,
+    BigDecimal("1.23"),
+    LocalDate.parse("1900-01-01"),
+    LocalDate.parse("1900-01-02"),
+    "description",
+    "reference"
+  )
+  private val creditTransaction = Transaction(
+    Credit,
+    BigDecimal("1.23"),
+    LocalDate.parse("1900-01-01"),
+    LocalDate.parse("1900-01-02"),
+    "description",
+    "reference",
+    BigDecimal(0)
+  )
+
+  private val nsiDebitTransaction: NsiTransaction = nsiCreditTransaction.copy(operation = "D")
+  private val validNsiDebitTransaction: ValidNsiTransaction = validNsiCreditTransaction.copy(operation = Debit)
+  private val debitTransaction: Transaction = creditTransaction.copy(operation = Debit)
+
+  private val nsiInvalidOperationTransaction: NsiTransaction = nsiCreditTransaction.copy(operation = "X")
+
+  private val nsiInvalidOperationTransaction2: NsiTransaction = nsiCreditTransaction.copy(operation = "")
+
+  "ValidNsiTransaction object" when {
+    "creating a new Transaction from a NsiTransaction" must {
+      "return transaction details for a credit" in {
+        ValidNsiTransaction(nsiCreditTransaction) shouldBe Valid(validNsiCreditTransaction)
+      }
+
+      "return transaction details for a debit" in {
+        ValidNsiTransaction(nsiDebitTransaction) shouldBe Valid(validNsiDebitTransaction)
+      }
+
+      "return an Invalid for an unknown operation" in {
+        ValidNsiTransaction(nsiInvalidOperationTransaction) shouldBe Invalid(NonEmptyList.one(
+          """Unknown value for operation: "X""""
+        ))
+      }
+
+      "return an Invalid for a sequence that cannot be parsed as an integer" in {
+        ValidNsiTransaction(nsiCreditTransaction.copy(sequence = "one")) shouldBe Invalid(NonEmptyList.one(
+          """Can't parse sequence value as an integer: "one""""
+        ))
+        ValidNsiTransaction(nsiCreditTransaction.copy(sequence = "1.1")) shouldBe Invalid(NonEmptyList.one(
+          """Can't parse sequence value as an integer: "1.1""""
+        ))
+      }
+    }
+  }
+
+  "Transactions object" when { // scalastyle:off magic.number
+    "creating a new Transactions from a NsiTransactions" must {
+      "return transactions details when input transactions are all valid" in {
+        val nsiTransactions = NsiTransactions(Seq(nsiCreditTransaction, nsiCreditTransaction.copy(sequence = "2"), nsiDebitTransaction.copy(sequence = "3")))
+        val expectedTransactions = Transactions(Seq(
+          creditTransaction.copy(balanceAfter = BigDecimal("1.23")),
+          creditTransaction.copy(balanceAfter = BigDecimal("2.46")),
+          debitTransaction.copy(balanceAfter = BigDecimal("1.23"))
+        ))
+        Transactions(nsiTransactions) shouldBe Valid(expectedTransactions)
+      }
+
+      "handle an empty transaction list" in {
+        val nsiTransactions = NsiTransactions(Seq())
+        val expectedTransactions = Transactions(Seq())
+        Transactions(nsiTransactions) shouldBe Valid(expectedTransactions)
+      }
+
+      "handle a 1-element transaction list" in {
+        val nsiTransactions = NsiTransactions(Seq(nsiDebitTransaction))
+        val expectedTransactions = Transactions(Seq(debitTransaction.copy(balanceAfter = 0 - validNsiDebitTransaction.amount)))
+        Transactions(nsiTransactions) shouldBe Valid(expectedTransactions)
+      }
+
+      "sort transactions by accountingDate then sequence" in {
+        val nsiTransactions = NsiTransactions(Seq(
+          nsiCreditTransaction.copy(sequence       = "1", accountingDate = LocalDate.parse("2018-04-10"), amount = BigDecimal(5)),
+          nsiCreditTransaction.copy(sequence       = "3", accountingDate = LocalDate.parse("2017-11-27"), amount = BigDecimal(3)),
+          nsiCreditTransaction.copy(sequence       = "4", accountingDate = LocalDate.parse("2017-11-27"), amount = BigDecimal(4)),
+          nsiDebitTransaction.copy(sequence       = "2", accountingDate = LocalDate.parse("2017-11-27"), amount = BigDecimal(2)),
+          nsiCreditTransaction.copy(sequence       = "1", accountingDate = LocalDate.parse("2017-11-20"), amount = BigDecimal(1))
+        ))
+
+        Transactions(nsiTransactions).bimap(errors ⇒ fail(errors.toList.mkString(", ")), { transactions ⇒
+          transactions.transactions.map(_.amount) shouldBe List(
+            BigDecimal(1),
+            BigDecimal(2),
+            BigDecimal(3),
+            BigDecimal(4),
+            BigDecimal(5)
+          )
+        })
+      }
+
+      "return an Invalid when any input transactions are invalid" in {
+        val nsiTransactions = NsiTransactions(Seq(nsiCreditTransaction, nsiInvalidOperationTransaction, nsiInvalidOperationTransaction2))
+        Transactions(nsiTransactions) shouldBe Invalid(NonEmptyList.of(
+          """Unknown value for operation: "X"""",
+          """Unknown value for operation: """""
+        ))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Also:
* Fix URL parameter escaping in get account.
* Don't log request body when JSON parsing fails in get account (in case the unparseable request body contains PII).
* Make logger.warn()s less noisy when JSON parsing fails in get account (previously HelpToSaveProxyConnector and AccountController would log similar things, now AccountController logs the error message returned by HelpToSaveProxyConnector).