### PR TITLE
NGC-3251 Log unparseable response bodies when running locally 

### DIFF
--- a/app/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnector.scala
+++ b/app/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnector.scala
@@ -133,6 +133,7 @@ class HelpToSaveProxyConnectorImpl @Inject() (http:              WSHttp,
                 { errors ⇒
                   metrics.getAccountErrorCounter.inc()
                   pagerDutyAlerting.alert("Could not parse JSON in the getAccount response")
+                  logger.debug(s"Response body that failed to parse: ${response.body}}")
                   s"Could not parse getNsiAccount response, received 200 (OK), error=[${errors.toList.mkString(",")}]"
                 },
                 { account ⇒
@@ -188,6 +189,7 @@ class HelpToSaveProxyConnectorImpl @Inject() (http:              WSHttp,
                 { errors ⇒
                   metrics.getTransactionsErrorCounter.inc()
                   pagerDutyAlerting.alert("Could not parse get transactions response")
+                  logger.debug(s"Response body that failed to parse: ${response.body}}")
                   s"""Could not parse transactions response from NS&I, received 200 (OK), error=[${errors.toList.mkString(",")}]"""
                 },
                 { transactions: Transactions ⇒

--- a/build.sbt
+++ b/build.sbt
@@ -112,6 +112,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(scalaVersion := "2.11.12")
   .settings(publishingSettings: _*)
   .settings(defaultSettings(): _*)
+  .settings(PlayKeys.playDefaultPort := 7001)
   .settings(scalariformSettings: _*)
   .settings(wartRemoverSettings)
   // disable some wart remover checks in tests - (Any, Null, PublicInference) seems to struggle with

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -47,6 +47,8 @@
 
     <logger name="uk.gov" level="INFO"/>
 
+    <logger name="uk.gov.hmrc.helptosave" level="DEBUG"/>
+
     <logger name="uk.gov.hmrc.audit" level="WARN"/>
 
     <logger name="application" level="INFO"/>


### PR DESCRIPTION
Also set default port in build.sbt so there's no need to pass it to `sbt run`