### PR TITLE
NGC-3264 Add openedYearMonth to get account

### DIFF
--- a/app/uk/gov/hmrc/helptosave/models/account/Account.scala
+++ b/app/uk/gov/hmrc/helptosave/models/account/Account.scala
@@ -28,7 +28,6 @@ import uk.gov.hmrc.helptosave.util.Logging
 
 case class BonusTerm(bonusEstimate:          BigDecimal,
                      bonusPaid:              BigDecimal,
-                     startDate:              LocalDate,
                      endDate:                LocalDate,
                      bonusPaidOnOrAfterDate: LocalDate)
 
@@ -116,7 +115,6 @@ object Account extends Logging {
   private def nsiBonusTermToBonusTerm(nsiBonusTerm: NsiBonusTerm): BonusTerm = BonusTerm(
     bonusEstimate          = nsiBonusTerm.bonusEstimate,
     bonusPaid              = nsiBonusTerm.bonusPaid,
-    startDate              = nsiBonusTerm.startDate,
     endDate                = nsiBonusTerm.endDate,
     bonusPaidOnOrAfterDate = nsiBonusTerm.endDate.plusDays(1)
   )

--- a/app/uk/gov/hmrc/helptosave/models/account/Account.scala
+++ b/app/uk/gov/hmrc/helptosave/models/account/Account.scala
@@ -16,18 +16,19 @@
 
 package uk.gov.hmrc.helptosave.models.account
 
-import java.time.LocalDate
+import java.time.{LocalDate, YearMonth}
 
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.instances.string._
 import cats.syntax.apply._
 import cats.syntax.eq._
-import play.api.libs.json.{Format, Json}
+import play.api.libs.json._
 import uk.gov.hmrc.helptosave.util.Logging
 
 case class BonusTerm(bonusEstimate:          BigDecimal,
                      bonusPaid:              BigDecimal,
+                     startDate:              LocalDate,
                      endDate:                LocalDate,
                      bonusPaidOnOrAfterDate: LocalDate)
 
@@ -41,7 +42,8 @@ object Blocking {
   implicit val writes: Format[Blocking] = Json.format[Blocking]
 }
 
-case class Account(accountNumber:          String,
+case class Account(openedYearMonth:        YearMonth,
+                   accountNumber:          String,
                    isClosed:               Boolean,
                    blocked:                Blocking,
                    balance:                BigDecimal,
@@ -77,9 +79,18 @@ object Account extends Logging {
         Invalid(NonEmptyList.one(s"""Unknown value for accountClosedFlag: "${nsiAccount.accountClosedFlag}""""))
       }
 
-    (paidInThisMonthValidation, accountClosedValidation).mapN{
-      case (paidInThisMonth, accountClosed) ⇒
+    val sortedNsiTerms = nsiAccount.terms.sortBy(_.termNumber)
+    val openedYearMonthValidation: ValidOrErrorString[YearMonth] =
+      sortedNsiTerms.headOption.fold[ValidOrErrorString[YearMonth]] {
+        Invalid(NonEmptyList.of("Bonus terms list returned by NS&I was empty"))
+      } { firstNsiTerm ⇒
+        Valid(YearMonth.from(firstNsiTerm.startDate))
+      }
+
+    (paidInThisMonthValidation, accountClosedValidation, openedYearMonthValidation).mapN{
+      case (paidInThisMonth, accountClosed, openedYearMonth) ⇒
         Account(
+          openedYearMonth        = openedYearMonth,
           accountNumber          = nsiAccount.accountNumber,
           isClosed               = accountClosed,
           blocked                = nsiAccountToBlocking(nsiAccount),
@@ -88,7 +99,7 @@ object Account extends Logging {
           canPayInThisMonth      = nsiAccount.currentInvestmentMonth.investmentRemaining,
           maximumPaidInThisMonth = nsiAccount.currentInvestmentMonth.investmentLimit,
           thisMonthEndDate       = nsiAccount.currentInvestmentMonth.endDate,
-          bonusTerms             = nsiAccount.terms.sortBy(_.termNumber).map(nsiBonusTermToBonusTerm),
+          bonusTerms             = sortedNsiTerms.map(nsiBonusTermToBonusTerm),
           closureDate            = nsiAccount.accountClosureDate,
           closingBalance         = nsiAccount.accountClosingBalance
         )
@@ -105,10 +116,15 @@ object Account extends Logging {
   private def nsiBonusTermToBonusTerm(nsiBonusTerm: NsiBonusTerm): BonusTerm = BonusTerm(
     bonusEstimate          = nsiBonusTerm.bonusEstimate,
     bonusPaid              = nsiBonusTerm.bonusPaid,
+    startDate              = nsiBonusTerm.startDate,
     endDate                = nsiBonusTerm.endDate,
     bonusPaidOnOrAfterDate = nsiBonusTerm.endDate.plusDays(1)
   )
 
-  implicit val format: Format[Account] = Json.format[Account]
+  implicit object YearMonthWrites extends Writes[YearMonth] {
+    def writes(yearMonth: YearMonth): JsValue = JsString(yearMonth.toString)
+  }
+
+  implicit val writes: Writes[Account] = Json.writes[Account]
 }
 

--- a/app/uk/gov/hmrc/helptosave/models/account/NsiAccount.scala
+++ b/app/uk/gov/hmrc/helptosave/models/account/NsiAccount.scala
@@ -30,7 +30,13 @@ object NsiCurrentInvestmentMonth {
   implicit val reads: Reads[NsiCurrentInvestmentMonth] = Json.reads[NsiCurrentInvestmentMonth]
 }
 
-case class NsiBonusTerm(termNumber: Int, endDate: LocalDate, bonusEstimate: BigDecimal, bonusPaid: BigDecimal)
+case class NsiBonusTerm(
+    termNumber:    Int,
+    startDate:     LocalDate,
+    endDate:       LocalDate,
+    bonusEstimate: BigDecimal,
+    bonusPaid:     BigDecimal
+)
 
 object NsiBonusTerm {
   implicit val reads: Reads[NsiBonusTerm] = Json.reads[NsiBonusTerm]

--- a/test/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnectorSpec.scala
@@ -245,8 +245,8 @@ class HelpToSaveProxyConnectorSpec extends TestSupport with MockPagerDuty with E
         50.00,
         LocalDate.parse("2018-02-28"),
         List(
-          BonusTerm(bonusEstimate          = 123.45, bonusPaid = 123.45, startDate = LocalDate.parse("2018-01-01"), endDate = LocalDate.parse("2019-12-31"), bonusPaidOnOrAfterDate = LocalDate.parse("2020-01-01")),
-          BonusTerm(bonusEstimate          = 67.00, bonusPaid = 0.00, startDate = LocalDate.parse("2020-01-01"), endDate = LocalDate.parse("2021-12-31"), bonusPaidOnOrAfterDate = LocalDate.parse("2022-01-01"))
+          BonusTerm(bonusEstimate          = 123.45, bonusPaid = 123.45, endDate = LocalDate.parse("2019-12-31"), bonusPaidOnOrAfterDate = LocalDate.parse("2020-01-01")),
+          BonusTerm(bonusEstimate          = 67.00, bonusPaid = 0.00, endDate = LocalDate.parse("2021-12-31"), bonusPaidOnOrAfterDate = LocalDate.parse("2022-01-01"))
         ),
         None,
         None)

--- a/test/uk/gov/hmrc/helptosave/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/controllers/AccountControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.helptosave.controllers
 
-import java.time.LocalDate
+import java.time.{LocalDate, YearMonth}
 import java.util.UUID
 
 import cats.data.EitherT
@@ -38,7 +38,7 @@ class AccountControllerSpec extends AuthSupport {
 
   val controller = new AccountController(mockProxyConnector, mockAuthConnector)
 
-  val account = Account("AC01", false, Blocking(false), 123.45, 0, 0, 0, LocalDate.parse("1900-01-01"), List(), None, None)
+  val account = Account(YearMonth.of(1900, 1), "AC01", false, Blocking(false), 123.45, 0, 0, 0, LocalDate.parse("1900-01-01"), List(), None, None)
 
   val queryString = s"nino=$nino&correlationId=${UUID.randomUUID()}&systemId=123"
 

--- a/test/uk/gov/hmrc/helptosave/models/account/AccountSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/models/account/AccountSpec.scala
@@ -16,9 +16,10 @@
 
 package uk.gov.hmrc.helptosave.models.account
 
-import java.time.LocalDate
+import java.time.{LocalDate, YearMonth}
 
-import cats.data.Validated.Valid
+import cats.data.NonEmptyList
+import cats.data.Validated.{Invalid, Valid}
 import uk.gov.hmrc.helptosave.utils.TestSupport
 
 // scalastyle:off magic.number
@@ -29,14 +30,20 @@ class AccountSpec extends TestSupport {
     accountBlockingCode    = "00",
     clientBlockingCode     = "00",
     accountBalance         = 0,
-    currentInvestmentMonth = NsiCurrentInvestmentMonth(0, 0, LocalDate.of(1900, 1, 1)),
-    terms                  = Seq.empty,
+    currentInvestmentMonth = NsiCurrentInvestmentMonth(0, 0, LocalDate.of(2018, 1, 31)),
+    terms                  = Seq(
+      NsiBonusTerm(termNumber    = 1, startDate = LocalDate.of(2018, 1, 1), endDate = LocalDate.of(2019, 12, 31), bonusEstimate = 0, bonusPaid = 0),
+      NsiBonusTerm(termNumber    = 2, startDate = LocalDate.of(2020, 1, 1), endDate = LocalDate.of(2021, 12, 31), bonusEstimate = 0, bonusPaid = 0)
+    ),
     accountNumber          = "AC01",
     accountClosureDate     = None,
     accountClosingBalance  = None
   )
 
-  val account = Account("AC01", false, Blocking(false), 123.45, 0, 0, 0, LocalDate.parse("1900-01-01"), List(), None, None)
+  val account = Account(YearMonth.of(2018, 1), "AC01", isClosed = false, Blocking(false), 123.45, 0, 0, 0, LocalDate.of(2018, 1, 31), Seq(
+    BonusTerm(startDate              = LocalDate.of(2018, 1, 1), endDate = LocalDate.of(2019, 12, 31), bonusEstimate = 0, bonusPaid = 0, bonusPaidOnOrAfterDate = LocalDate.of(2020, 1, 1)),
+    BonusTerm(startDate              = LocalDate.of(2020, 1, 1), endDate = LocalDate.of(2021, 12, 31), bonusEstimate = 0, bonusPaid = 0, bonusPaidOnOrAfterDate = LocalDate.of(2022, 1, 1))
+  ), None, None)
 
   "Account class" when {
     "creating a new class from NsiAccount class" must {
@@ -69,7 +76,12 @@ class AccountSpec extends TestSupport {
           accountClosingBalance = Some(BigDecimal("123.45"))
         ))
 
-        returnedAccount shouldBe Valid(Account("AC01", true, Blocking(false), 0, 0, 0, 0, LocalDate.parse("1900-01-01"), List.empty, Some(LocalDate.of(2018, 2, 16)), Some(123.45)))
+        returnedAccount shouldBe Valid(account.copy(
+          isClosed       = true,
+          balance        = 0,
+          closureDate    = Some(LocalDate.of(2018, 2, 16)),
+          closingBalance = Some(123.45)
+        ))
       }
 
       "return details for current month" in {
@@ -99,23 +111,51 @@ class AccountSpec extends TestSupport {
 
       "return bonus information including calculated bonusPaidOnOrAfterDate" in {
         val returnedAccount = Account(testNsiAccount.copy(
-          terms = Seq(NsiBonusTerm(termNumber    = 1, endDate = LocalDate.of(2020, 10, 22), bonusEstimate = BigDecimal("65.43"), bonusPaid = 0))))
+          terms = Seq(NsiBonusTerm(termNumber    = 1, startDate = LocalDate.of(2018, 10, 23), endDate = LocalDate.of(2020, 10, 22), bonusEstimate = BigDecimal("65.43"), bonusPaid = 0))))
 
-        val bonusTerms = BonusTerm(bonusEstimate          = BigDecimal("65.43"), bonusPaid = 0, endDate = LocalDate.of(2020, 10, 22), bonusPaidOnOrAfterDate = LocalDate.of(2020, 10, 23))
-        returnedAccount shouldBe Valid(account.copy(balance    = 0, bonusTerms = List(bonusTerms)))
+        val bonusTerm = BonusTerm(bonusEstimate          = BigDecimal("65.43"), bonusPaid = 0, startDate = LocalDate.of(2018, 10, 23), endDate = LocalDate.of(2020, 10, 22), bonusPaidOnOrAfterDate = LocalDate.of(2020, 10, 23))
+        returnedAccount shouldBe Valid(account.copy(
+          openedYearMonth = YearMonth.of(2018, 10),
+          balance         = 0,
+          bonusTerms      = List(bonusTerm)
+        ))
       }
 
       "sort the bonus terms by termNumber" in {
         val returnedAccount = Account(testNsiAccount.copy(
           accountBalance = BigDecimal("200.34"),
           terms          = Seq(
-            NsiBonusTerm(termNumber    = 2, endDate = LocalDate.of(2021, 12, 31), bonusEstimate = 67, bonusPaid = 0),
-            NsiBonusTerm(termNumber    = 1, endDate = LocalDate.of(2019, 12, 31), bonusEstimate = BigDecimal("123.45"), bonusPaid = BigDecimal("123.45"))
+            NsiBonusTerm(termNumber    = 2, startDate = LocalDate.of(2020, 1, 1), endDate = LocalDate.of(2021, 12, 31), bonusEstimate = 67, bonusPaid = 0),
+            NsiBonusTerm(termNumber    = 1, startDate = LocalDate.of(2018, 1, 1), endDate = LocalDate.of(2019, 12, 31), bonusEstimate = BigDecimal("123.45"), bonusPaid = BigDecimal("123.45"))
           )))
 
-        val bonusTerm1 = BonusTerm(bonusEstimate          = BigDecimal("67"), bonusPaid = 0, endDate = LocalDate.of(2021, 12, 31), bonusPaidOnOrAfterDate = LocalDate.of(2022, 1, 1))
-        val bonusTerm2 = BonusTerm(bonusEstimate          = BigDecimal("123.45"), bonusPaid = 123.45, endDate = LocalDate.of(2019, 12, 31), bonusPaidOnOrAfterDate = LocalDate.of(2020, 1, 1))
-        returnedAccount shouldBe Valid(account.copy(balance    = 200.34, bonusTerms = List(bonusTerm2, bonusTerm1)))
+        val bonusTerm1 = BonusTerm(bonusEstimate          = BigDecimal("67"), bonusPaid = 0, startDate = LocalDate.of(2020, 1, 1), endDate = LocalDate.of(2021, 12, 31), bonusPaidOnOrAfterDate = LocalDate.of(2022, 1, 1))
+        val bonusTerm2 = BonusTerm(bonusEstimate          = BigDecimal("123.45"), bonusPaid = 123.45, startDate = LocalDate.of(2018, 1, 1), endDate = LocalDate.of(2019, 12, 31), bonusPaidOnOrAfterDate = LocalDate.of(2020, 1, 1))
+        returnedAccount shouldBe Valid(account.copy(
+          openedYearMonth = YearMonth.of(2018, 1),
+          balance         = 200.34,
+          bonusTerms      = List(bonusTerm2, bonusTerm1)
+        ))
+      }
+
+      "calculate openedYearMonth based on start of first bonus term" in {
+        val returnedAccount = Account(testNsiAccount.copy(
+          terms = Seq(
+            NsiBonusTerm(termNumber    = 2, startDate = LocalDate.of(2020, 1, 1), endDate = LocalDate.of(2021, 12, 31), bonusEstimate = 67, bonusPaid = 0),
+            NsiBonusTerm(termNumber    = 1, startDate = LocalDate.of(2018, 1, 1), endDate = LocalDate.of(2019, 12, 31), bonusEstimate = BigDecimal("123.45"), bonusPaid = BigDecimal("123.45"))
+          )))
+
+        returnedAccount.bimap(
+          errors ⇒ fail(s"returnedAccount should have been Valid but was Invalid with errors $errors"),
+          account ⇒ account.openedYearMonth shouldBe YearMonth.of(2018, 1)
+        )
+      }
+
+      // NS&I should always return 2 terms, and we need at least the first one to calculate openedYearMonth
+      "return an Invalid when the NS&I account does not contain any bonus terms" in {
+        val returnedAccount = Account(testNsiAccount.copy(terms = Seq.empty))
+
+        returnedAccount shouldBe Invalid(NonEmptyList.of("Bonus terms list returned by NS&I was empty"))
       }
     }
   }

--- a/test/uk/gov/hmrc/helptosave/models/account/AccountSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/models/account/AccountSpec.scala
@@ -41,8 +41,8 @@ class AccountSpec extends TestSupport {
   )
 
   val account = Account(YearMonth.of(2018, 1), "AC01", isClosed = false, Blocking(false), 123.45, 0, 0, 0, LocalDate.of(2018, 1, 31), Seq(
-    BonusTerm(startDate              = LocalDate.of(2018, 1, 1), endDate = LocalDate.of(2019, 12, 31), bonusEstimate = 0, bonusPaid = 0, bonusPaidOnOrAfterDate = LocalDate.of(2020, 1, 1)),
-    BonusTerm(startDate              = LocalDate.of(2020, 1, 1), endDate = LocalDate.of(2021, 12, 31), bonusEstimate = 0, bonusPaid = 0, bonusPaidOnOrAfterDate = LocalDate.of(2022, 1, 1))
+    BonusTerm(endDate                = LocalDate.of(2019, 12, 31), bonusEstimate = 0, bonusPaid = 0, bonusPaidOnOrAfterDate = LocalDate.of(2020, 1, 1)),
+    BonusTerm(endDate                = LocalDate.of(2021, 12, 31), bonusEstimate = 0, bonusPaid = 0, bonusPaidOnOrAfterDate = LocalDate.of(2022, 1, 1))
   ), None, None)
 
   "Account class" when {
@@ -113,7 +113,7 @@ class AccountSpec extends TestSupport {
         val returnedAccount = Account(testNsiAccount.copy(
           terms = Seq(NsiBonusTerm(termNumber    = 1, startDate = LocalDate.of(2018, 10, 23), endDate = LocalDate.of(2020, 10, 22), bonusEstimate = BigDecimal("65.43"), bonusPaid = 0))))
 
-        val bonusTerm = BonusTerm(bonusEstimate          = BigDecimal("65.43"), bonusPaid = 0, startDate = LocalDate.of(2018, 10, 23), endDate = LocalDate.of(2020, 10, 22), bonusPaidOnOrAfterDate = LocalDate.of(2020, 10, 23))
+        val bonusTerm = BonusTerm(bonusEstimate          = BigDecimal("65.43"), bonusPaid = 0, endDate = LocalDate.of(2020, 10, 22), bonusPaidOnOrAfterDate = LocalDate.of(2020, 10, 23))
         returnedAccount shouldBe Valid(account.copy(
           openedYearMonth = YearMonth.of(2018, 10),
           balance         = 0,
@@ -129,8 +129,8 @@ class AccountSpec extends TestSupport {
             NsiBonusTerm(termNumber    = 1, startDate = LocalDate.of(2018, 1, 1), endDate = LocalDate.of(2019, 12, 31), bonusEstimate = BigDecimal("123.45"), bonusPaid = BigDecimal("123.45"))
           )))
 
-        val bonusTerm1 = BonusTerm(bonusEstimate          = BigDecimal("67"), bonusPaid = 0, startDate = LocalDate.of(2020, 1, 1), endDate = LocalDate.of(2021, 12, 31), bonusPaidOnOrAfterDate = LocalDate.of(2022, 1, 1))
-        val bonusTerm2 = BonusTerm(bonusEstimate          = BigDecimal("123.45"), bonusPaid = 123.45, startDate = LocalDate.of(2018, 1, 1), endDate = LocalDate.of(2019, 12, 31), bonusPaidOnOrAfterDate = LocalDate.of(2020, 1, 1))
+        val bonusTerm1 = BonusTerm(bonusEstimate          = BigDecimal("67"), bonusPaid = 0, endDate = LocalDate.of(2021, 12, 31), bonusPaidOnOrAfterDate = LocalDate.of(2022, 1, 1))
+        val bonusTerm2 = BonusTerm(bonusEstimate          = BigDecimal("123.45"), bonusPaid = 123.45, endDate = LocalDate.of(2019, 12, 31), bonusPaidOnOrAfterDate = LocalDate.of(2020, 1, 1))
         returnedAccount shouldBe Valid(account.copy(
           openedYearMonth = YearMonth.of(2018, 1),
           balance         = 200.34,

--- a/test/uk/gov/hmrc/helptosave/models/account/YearMonthJsonSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/models/account/YearMonthJsonSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.models.account
+
+import java.time.YearMonth
+
+import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.{JsString, Json}
+
+class YearMonthJsonSpec extends WordSpec with Matchers {
+  "YearMonth JSON" should {
+    "be YYYY-MM" in {
+      import Account.YearMonthWrites
+      Json.toJson(YearMonth.of(1999, 12)) shouldBe JsString("1999-12")
+    }
+  }
+}


### PR DESCRIPTION
If you'd like to include bonusTerms.startDate as well that can easily be added by reverting the last commit in this PR.