### PR TITLE
[NGC-3394][BL] Remove accounting date sorting from transactions

### DIFF
--- a/app/uk/gov/hmrc/helptosave/models/account/Transactions.scala
+++ b/app/uk/gov/hmrc/helptosave/models/account/Transactions.scala
@@ -122,13 +122,7 @@ object Transactions {
   private implicit val eqLocalDate: Eq[LocalDate] = Eq.instance(_.isEqual(_))
 
   private def sortLikeNsiWeb(transactions: Seq[ValidNsiTransaction]): Seq[ValidNsiTransaction] = {
-    transactions.sortWith { (t1, t2) ⇒
-      if (t1.accountingDate === t2.accountingDate) {
-        t1.sequence < t2.sequence
-      } else {
-        t1.accountingDate.isBefore(t2.accountingDate)
-      }
-    }
+    transactions.sortWith { (t1, t2) ⇒ t1.sequence < t2.sequence }
   }
 
   private def runningBalance(transactions: Seq[ValidNsiTransaction]): Seq[Transaction] = {

--- a/test/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnectorSpec.scala
@@ -401,7 +401,7 @@ class HelpToSaveProxyConnectorSpec extends TestSupport with MockPagerDuty with E
             |      "accountingDate": "2017-12-04"
             |    },
             |    {
-            |      "sequence": "1",
+            |      "sequence": "5",
             |      "amount": "50.00",
             |      "operation": "C",
             |      "description": "Debit card online deposit",

--- a/test/uk/gov/hmrc/helptosave/models/account/TransactionsSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/models/account/TransactionsSpec.scala
@@ -111,9 +111,9 @@ class TransactionsSpec extends TestSupport {
         Transactions(nsiTransactions) shouldBe Valid(expectedTransactions)
       }
 
-      "sort transactions by accountingDate then sequence" in {
+      "sort transactions by sequence number" in {
         val nsiTransactions = NsiTransactions(Seq(
-          nsiCreditTransaction.copy(sequence       = "1", accountingDate = LocalDate.parse("2018-04-10"), amount = BigDecimal(5)),
+          nsiCreditTransaction.copy(sequence       = "5", accountingDate = LocalDate.parse("2018-04-10"), amount = BigDecimal(5)),
           nsiCreditTransaction.copy(sequence       = "3", accountingDate = LocalDate.parse("2017-11-27"), amount = BigDecimal(3)),
           nsiCreditTransaction.copy(sequence       = "4", accountingDate = LocalDate.parse("2017-11-27"), amount = BigDecimal(4)),
           nsiDebitTransaction.copy(sequence       = "2", accountingDate = LocalDate.parse("2017-11-27"), amount = BigDecimal(2)),


### PR DESCRIPTION
A bug in the initial implementation of the NS&I API meant that the sequence of
transactions reset to 1 at the beggining of each year. To retain the correct
ordering (as set out in the ICD) we had to additionally sort by the accounting
date. The bug is now marked as fixed so the sequence should be reliably
monotonic.