### PR TITLE
HTS-1132 - added blocked from payments flag to account

### DIFF
--- a/app/uk/gov/hmrc/helptosave/models/account/Account.scala
+++ b/app/uk/gov/hmrc/helptosave/models/account/Account.scala
@@ -86,13 +86,15 @@ object Account extends Logging {
         Valid(YearMonth.from(firstNsiTerm.startDate))
       }
 
-    (paidInThisMonthValidation, accountClosedValidation, openedYearMonthValidation).mapN{
-      case (paidInThisMonth, accountClosed, openedYearMonth) ⇒
+    val blockingValidation: ValidOrErrorString[Blocking] = nsiAccountToBlockingValidation(nsiAccount)
+
+    (paidInThisMonthValidation, accountClosedValidation, openedYearMonthValidation, blockingValidation).mapN{
+      case (paidInThisMonth, accountClosed, openedYearMonth, blocking) ⇒
         Account(
           openedYearMonth        = openedYearMonth,
           accountNumber          = nsiAccount.accountNumber,
           isClosed               = accountClosed,
-          blocked                = nsiAccountToBlocking(nsiAccount),
+          blocked                = blocking,
           balance                = nsiAccount.accountBalance,
           paidInThisMonth        = paidInThisMonth,
           canPayInThisMonth      = nsiAccount.currentInvestmentMonth.investmentRemaining,
@@ -108,14 +110,24 @@ object Account extends Logging {
 
   private type ValidOrErrorString[A] = ValidatedNel[String, A]
 
-  private def nsiAccountToBlocking(nsiAccount: NsiAccount): Blocking = {
-      def isBlockedFromPredicate(predicate: String ⇒ Boolean): Boolean =
-        predicate(nsiAccount.accountBlockingCode) || predicate(nsiAccount.clientBlockingCode)
+  private val expectedBlockingCodes: Set[String] = Set("00", "11", "12", "13", "15", "30", "64")
 
-    Blocking(
-      unspecified = isBlockedFromPredicate(_ =!= "00"),
-      payments    = isBlockedFromPredicate(s ⇒ s =!= "00" && s =!= "11")
-    )
+  private def nsiAccountToBlockingValidation(nsiAccount: NsiAccount): ValidatedNel[String, Blocking] = {
+      def checkIsValidCode(code: String): ValidOrErrorString[String] =
+        if (expectedBlockingCodes.contains(code)) { Valid(code) } else { Invalid(NonEmptyList.one(s"Received unexpected blocking code: $code")) }
+
+    (checkIsValidCode(nsiAccount.accountBlockingCode), checkIsValidCode(nsiAccount.clientBlockingCode))
+      .mapN{
+        case (accountBlockingCode, clientBlockingCode) ⇒
+          def isBlockedFromPredicate(predicate: String ⇒ Boolean): Boolean =
+              predicate(accountBlockingCode) || predicate(clientBlockingCode)
+
+          Blocking(
+            unspecified = isBlockedFromPredicate(_ =!= "00"),
+            payments    = isBlockedFromPredicate(s ⇒ s =!= "00" && s =!= "11")
+          )
+
+      }
   }
 
   private def nsiBonusTermToBonusTerm(nsiBonusTerm: NsiBonusTerm): BonusTerm = BonusTerm(

--- a/test/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/connectors/HelpToSaveProxyConnectorSpec.scala
@@ -241,7 +241,7 @@ class HelpToSaveProxyConnectorSpec extends TestSupport with MockPagerDuty with E
       val account = Account(
         YearMonth.of(2018, 1),
         "AC01", false,
-        Blocking(false),
+        Blocking(false, false),
         200.34,
         34.50,
         15.50,

--- a/test/uk/gov/hmrc/helptosave/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/controllers/AccountControllerSpec.scala
@@ -39,7 +39,7 @@ class AccountControllerSpec extends AuthSupport {
 
   val controller = new AccountController(mockProxyConnector, mockAuthConnector)
 
-  val account = Account(YearMonth.of(1900, 1), "AC01", false, Blocking(false), 123.45, 0, 0, 0, LocalDate.parse("1900-01-01"), List(), None, None)
+  val account = Account(YearMonth.of(1900, 1), "AC01", false, Blocking(false, false), 123.45, 0, 0, 0, LocalDate.parse("1900-01-01"), List(), None, None)
 
   val queryString = s"nino=$nino&correlationId=${UUID.randomUUID()}&systemId=123"
 


### PR DESCRIPTION
We would like to expose a flag which indicates whether or not payments into the account are blocked. The changes here are based on a query to NS&I on which blocking codes indicate such a state - their response was this table:


 Code | Description | Can user make payments?
  ---- | ---- | ---
  00 | No blocking | YES 
 11 | Block Applicant (i.e. Power) from withdrawing money | YES 
  12 | Block Applicant (i.e. Power) from paying money in | NO 
  13 | Block all Applicant (i.e. Power) permissions including Portal access | NO 
  15 | Block credits & Block Bonus Payments | NO 
  30 | Stop All | NO 
  61 | Stop all credits | NO 
  64 | Block all credits. Block all debits. Block Portal access | NO 

