### PR TITLE
[CU][DLS-4126]: Removed duplicate header "User-Agent" as this is buil…

### DIFF
--- a/app/uk/gov/hmrc/helptosave/connectors/BarsConnector.scala
+++ b/app/uk/gov/hmrc/helptosave/connectors/BarsConnector.scala
@@ -41,7 +41,7 @@ class BarsConnectorImpl @Inject() (http: HttpClient)(implicit appConfig: AppConf
 
   private val barsEndpoint: String = s"${appConfig.barsUrl}/validateBankDetails"
 
-  private val headers = Map("User-Agent" -> "help-to-save", "Content-Type" -> "application/json")
+  private val headers = Map("Content-Type" -> "application/json")
 
   override def validate(request: BankDetailsValidationRequest, trackingId: UUID)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
     http.post(barsEndpoint, bodyJson(request), headers.+("X-Tracking-Id" -> trackingId.toString))

--- a/test/uk/gov/hmrc/helptosave/connectors/BarsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/connectors/BarsConnectorSpec.scala
@@ -34,7 +34,7 @@ class BarsConnectorSpec extends TestSupport with HttpSupport {
 
       "set headers and request body as expected and return http response to the caller" in {
         val trackingId = UUID.randomUUID()
-        val headers = Map("User-Agent" -> "help-to-save", "Content-Type" -> "application/json", "X-Tracking-Id" -> trackingId.toString)
+        val headers = Map("Content-Type" -> "application/json", "X-Tracking-Id" -> trackingId.toString)
         val body = Json.parse(
           """{
             | "account": {


### PR DESCRIPTION
…t by default in HeaderCarrier and is also carried automatically to external calls