### PR TITLE
[SM][DLS-6603] Replaced hmrc-lock with hmrc-mongo-lock, also removed …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ val dependencies = Seq(
   hmrc                %% "domain"                           % s"6.2.0-$playVersion",
   "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"               % mongoVersion,
   hmrc                %% "crypto"                           % "6.0.0",
-  hmrc                %% "mongo-lock"                       % s"7.0.0-$playVersion",
   "org.typelevel"     %% "cats-core"                        % "2.2.0",
   "com.github.kxbmap" %% "configs"                          % "0.6.1",
   compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.5" cross CrossVersion.full),

--- a/test/uk/gov/hmrc/helptosave/util/lock/LockSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/util/lock/LockSpec.scala
@@ -33,7 +33,7 @@ class LockSpec extends ActorTestSupport("LockSpec") {
 
   val time: VirtualTime = new VirtualTime
 
-  trait TestableExclusiveTimePeriodLock extends LockProvider {
+  trait TimePeriodLock extends LockProvider {
 
     override val lockId: String = testLockID
 
@@ -41,7 +41,7 @@ class LockSpec extends ActorTestSupport("LockSpec") {
 
   }
 
-  val internalLock = mock[TestableExclusiveTimePeriodLock]
+  val internalLock = mock[TimePeriodLock]
 
   def sendToSelf[A](a: A): A = {
     self ! a


### PR DESCRIPTION
…mongo-lock dependency. Due to this service using a release lock we couldn't use the TimePeriodLockService because it didn't contain a function to release the lock.

Signed-off-by: Sean Murray <sean.murray@digital.hmrc.gov.uk>