### PR TITLE
Tom/DLS-7230 updated bootstrap backend and akka testkit 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val mongoVersion = "0.68.0"
 
 val dependencies = Seq(
   ws,
-  hmrc                %% s"bootstrap-backend-$playVersion"  % "5.12.0",
+  hmrc                %% s"bootstrap-backend-$playVersion"  % "5.25.0",
   hmrc                %% "domain"                           % s"6.2.0-$playVersion",
   "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"               % mongoVersion,
   hmrc                %% "crypto"                           % "6.0.0",
@@ -32,7 +32,7 @@ val dependencies = Seq(
 )
 
 def testDependencies(scope: String = "test,it") = Seq(
-  hmrc                    %% s"bootstrap-test-$playVersion"   % "5.12.0"                % scope,
+  hmrc                    %% s"bootstrap-test-$playVersion"   % "5.25.0"                % scope,
   hmrc                    %% "service-integration-test"       % s"1.1.0-$playVersion"   % scope,
   hmrc                    %% "domain"                         % s"6.2.0-$playVersion"   % scope,
   hmrc                    %% "stub-data-generator"            % "0.5.3"                 % scope,
@@ -43,7 +43,7 @@ def testDependencies(scope: String = "test,it") = Seq(
   "com.typesafe.play"     %% "play-test"                      % PlayVersion.current     % scope,
   "org.scalamock"         %% "scalamock-scalatest-support"    % "3.6.0"                 % scope,
   "com.miguno.akka"       %% "akka-mock-scheduler"            % "0.5.1"                 % scope,
-  "com.typesafe.akka"     %% "akka-testkit"                   % "2.6.14"                % scope
+  "com.typesafe.akka"     %% "akka-testkit"                   % "2.6.19"                % scope
 )
 
 lazy val scoverageSettings = {

--- a/build.sbt
+++ b/build.sbt
@@ -18,10 +18,11 @@ lazy val plugins: Seq[Plugins] = Seq.empty
 val hmrc = "uk.gov.hmrc"
 val playVersion = "play-28"
 val mongoVersion = "0.68.0"
+val bootstrapBackendVersion = "5.25.0"
 
 val dependencies = Seq(
   ws,
-  hmrc                %% s"bootstrap-backend-$playVersion"  % "5.25.0",
+  hmrc                %% s"bootstrap-backend-$playVersion"  % bootstrapBackendVersion,
   hmrc                %% "domain"                           % s"6.2.0-$playVersion",
   "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"               % mongoVersion,
   hmrc                %% "crypto"                           % "6.0.0",
@@ -32,18 +33,18 @@ val dependencies = Seq(
 )
 
 def testDependencies(scope: String = "test,it") = Seq(
-  hmrc                    %% s"bootstrap-test-$playVersion"   % "5.25.0"                % scope,
-  hmrc                    %% "service-integration-test"       % s"1.1.0-$playVersion"   % scope,
-  hmrc                    %% "domain"                         % s"6.2.0-$playVersion"   % scope,
-  hmrc                    %% "stub-data-generator"            % "0.5.3"                 % scope,
-  "uk.gov.hmrc.mongo"     %% "hmrc-mongo-test-play-28"        % mongoVersion            % scope,
-  "org.scalatest"         %% "scalatest"                      % "3.2.9"                 % scope,
-  "org.scalatestplus"     %% "scalatestplus-scalacheck"       % "3.1.0.0-RC2"           % scope,
-  "com.vladsch.flexmark"  %  "flexmark-all"                   % "0.35.10"               % scope,
-  "com.typesafe.play"     %% "play-test"                      % PlayVersion.current     % scope,
-  "org.scalamock"         %% "scalamock-scalatest-support"    % "3.6.0"                 % scope,
-  "com.miguno.akka"       %% "akka-mock-scheduler"            % "0.5.1"                 % scope,
-  "com.typesafe.akka"     %% "akka-testkit"                   % "2.6.19"                % scope
+  hmrc                    %% s"bootstrap-test-$playVersion"   % bootstrapBackendVersion                % scope,
+  hmrc                    %% "service-integration-test"       % s"1.1.0-$playVersion"                  % scope,
+  hmrc                    %% "domain"                         % s"6.2.0-$playVersion"                  % scope,
+  hmrc                    %% "stub-data-generator"            % "0.5.3"                                % scope,
+  "uk.gov.hmrc.mongo"     %% "hmrc-mongo-test-play-28"        % mongoVersion                           % scope,
+  "org.scalatest"         %% "scalatest"                      % "3.2.9"                                % scope,
+  "org.scalatestplus"     %% "scalatestplus-scalacheck"       % "3.1.0.0-RC2"                          % scope,
+  "com.vladsch.flexmark"  %  "flexmark-all"                   % "0.35.10"                              % scope,
+  "com.typesafe.play"     %% "play-test"                      % PlayVersion.current                    % scope,
+  "org.scalamock"         %% "scalamock-scalatest-support"    % "3.6.0"                                % scope,
+  "com.miguno.akka"       %% "akka-mock-scheduler"            % "0.5.1"                                % scope,
+  "com.typesafe.akka"     %% "akka-testkit"                   % "2.6.19"                               % scope
 )
 
 lazy val scoverageSettings = {

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -5,11 +5,7 @@
         <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
     </appender>
 
-    <logger name="uk.gov" level="INFO"/>
-    
-    <logger name="uk.gov.hmrc.audit.handler" level="WARN"/>
-
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
Updated bootstrap backend to 5.25.0, caused errors and to avoid rewriting tests in this ticket I updated the akka testkit dependency. 

[Ticket](https://github.com/hmrc/help-to-save/pull/255)