### PR TITLE
Tom/DLS-7051 - BARS Allow 'indeterminate' as a Valid Response + added tests for 'indeterminate' response

### DIFF
--- a/app/uk/gov/hmrc/helptosave/services/BarsService.scala
+++ b/app/uk/gov/hmrc/helptosave/services/BarsService.scala
@@ -84,7 +84,7 @@ class BarsServiceImpl @Inject() (barsConnector: BarsConnector,
                       false
                     } else if (accountNumberWithSortCodeIsValid === "indeterminate") {
                       logger.info("BARS response: bank details were marked as indeterminate", nino)
-                      false
+                      true
                     } else {
                       logger.warn("BARS response: Unexpected Return for valid vank details", nino)
                       false

--- a/build.sbt
+++ b/build.sbt
@@ -130,7 +130,7 @@ lazy val wartRemoverSettings = {
 lazy val catsSettings = scalacOptions ++= Seq("-Ypartial-unification","-deprecation", "-feature")
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory) ++ plugins: _*)
+  .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin) ++ plugins: _*)
   .settings(addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.17"))
   .settings(majorVersion := 2)
   .settings(playSettings ++ scoverageSettings: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,6 @@ val dependencies = Seq(
   hmrc                %% s"bootstrap-backend-$playVersion"  % "5.12.0",
   hmrc                %% "domain"                           % s"6.2.0-$playVersion",
   "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"               % mongoVersion,
-  hmrc                %% "crypto"                           % "6.0.0",
   "org.typelevel"     %% "cats-core"                        % "2.2.0",
   "com.github.kxbmap" %% "configs"                          % "0.6.1",
   compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.5" cross CrossVersion.full),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -69,12 +69,6 @@ play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 # timeout 15 minutes after login (regardless of user activity).
 # session.maxAge=900
 
-# Secret key
-# ~~~~~
-# The secret key is used to secure cryptographics functions.
-# If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret = "s6P7A361Pc3qh954bfqLg9DEQdJAsUVEuRxAeJclwOUJAGynKAweBa4OyUVhr6Jl"
-
 # Session configuration
 # ~~~~~
 application.session.httpOnly = false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,6 @@ resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksam
 
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.5.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-git-versioning"     % "2.2.0")
-addSbtPlugin("uk.gov.hmrc"        %  "sbt-artifactory"        % "1.14.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.1.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-bobby"              % "3.5.0")
 addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.8")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,10 +4,10 @@ resolvers += Resolver.jcenterRepo
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.5.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-git-versioning"     % "2.2.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.1.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-bobby"              % "3.5.0")
+addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.9.0")
 addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.8")
 addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "1.8.0")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"  % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,9 +4,7 @@ resolvers += Resolver.jcenterRepo
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"        %  "sbt-git-versioning"     % "2.2.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.1.0")
-addSbtPlugin("uk.gov.hmrc"        %  "sbt-bobby"              % "3.5.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.9.0")
 addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.8")
 addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "1.8.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,8 @@ resolvers += Resolver.jcenterRepo
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.1.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.9.0")
+addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.2.0")
 addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.8")
 addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "1.8.0")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"  % "1.0.0")

--- a/test/uk/gov/hmrc/helptosave/services/BarsServiceSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/services/BarsServiceSpec.scala
@@ -101,6 +101,17 @@ class BarsServiceSpec extends UnitSpec with TestSupport with MockPagerDuty {
         result shouldBe Right(BankDetailsValidationResult(true, false))
       }
 
+      "handle the case when the bank details are indeterminate" in {
+        val response = newResponse("indeterminate", "no")
+
+        inSequence {
+          mockBarsConnector(barsRequest)(Some(HttpResponse(200, Json.parse(response), returnHeaders)))
+          mockAuditBarsEvent(BARSCheck(barsRequest, Json.parse(response), path), nino)
+        }
+        val result = await(service.validate(barsRequest))
+        result shouldBe Right(BankDetailsValidationResult(true, false))
+      }
+
       "handle the case when the bank details are valid but the sort code response cannot be parsed" in {
         val response = newResponse("yes", "blah")
 


### PR DESCRIPTION
This PR addresses: [Ticket](https://jira.tools.tax.service.gov.uk/browse/DLS-7051)

We now allow 'indeterminate' responses and test for them.
I couldn't find any resources leading to what 'indeterminate' means specifically, so assuming it covers a few cases I went with general naming of the test.