### PR TITLE
Use syntax instead of functions

### DIFF
--- a/app/uk/gov/hmrc/helptosave/actors/UCThresholdConnectorProxyActor.scala
+++ b/app/uk/gov/hmrc/helptosave/actors/UCThresholdConnectorProxyActor.scala
@@ -43,13 +43,13 @@ class UCThresholdConnectorProxyActor(dESConnector: DESConnector, pagerDutyAlerti
       response.status match {
         case Status.OK =>
           val result = response.parseJson[UCThreshold]
-          result.fold({
-            e =>
+          result match {
+            case Left(e) =>
               logger.warn(s"Could not parse JSON response from threshold, received 200 (OK): $e, with additionalParams: $additionalParams")
               pagerDutyAlerting.alert("Could not parse JSON in UC threshold response")
-          }, _ =>
-            logger.debug(s"Call to threshold successful, received 200 (OK), with additionalParams: $additionalParams")
-          )
+            case Right(_) =>
+              logger.debug(s"Call to threshold successful, received 200 (OK), with additionalParams: $additionalParams")
+          }
           result.map(_.thresholdAmount)
 
         case other =>

--- a/app/uk/gov/hmrc/helptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/helptosave/controllers/HelpToSaveController.scala
@@ -91,8 +91,11 @@ class HelpToSaveController @Inject() (val enrolmentStore:         EnrolmentStore
     implicit request =>
       request.body.asJson.map(_.validate[NSIPayload](NSIPayload.nsiPayloadReads(None))) match {
         case Some(JsSuccess(userInfo, _)) =>
-          proxyConnector.updateEmail(userInfo).map { response =>
-            Option(response.body).fold[Result](Status(response.status))(body => Status(response.status)(body))
+          for {
+            response <- proxyConnector.updateEmail(userInfo)
+          } yield Option(response.body) match {
+            case None       => Status(response.status)
+            case Some(body) => Status(response.status)(body)
           }
 
         case Some(error: JsError) =>

--- a/app/uk/gov/hmrc/helptosave/controllers/PayePersonalDetailsController.scala
+++ b/app/uk/gov/hmrc/helptosave/controllers/PayePersonalDetailsController.scala
@@ -41,16 +41,13 @@ class PayePersonalDetailsController @Inject() (val helpToSaveService: HelpToSave
   val base64Decoder: Base64.Decoder = Base64.getDecoder()
 
   def getPayePersonalDetails(nino: String): Action[AnyContent] = authorisedFromStride { implicit request =>
-    helpToSaveService.getPersonalDetails(nino)
-      .fold(
-        { error =>
-          logger.warn(s"Could not retrieve paye-personal-details from DES: $error", nino)
-          InternalServerError
-        }, {
-          r =>
-            Ok(Json.toJson(r))
-        }
-      )
+    (for {
+      r <- helpToSaveService.getPersonalDetails(nino)
+    } yield Ok(Json.toJson(r))).valueOrF{
+      error =>
+        logger.warn(s"Could not retrieve paye-personal-details from DES: $error", nino)
+        InternalServerError
+    }
   }
 
 }

--- a/app/uk/gov/hmrc/helptosave/services/HelpToSaveService.scala
+++ b/app/uk/gov/hmrc/helptosave/services/HelpToSaveService.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.helptosave.services
 
 import java.util.UUID
-
 import cats.data.EitherT
 import cats.syntax.eq._
 import cats.instances.int._
@@ -42,6 +41,7 @@ import uk.gov.hmrc.helptosave.util.HttpResponseOps._
 import uk.gov.hmrc.helptosave.util.toFuture
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.chaining.scalaUtilChainingOps
 import scala.util.control.NonFatal
 
 @ImplementedBy(classOf[HelpToSaveServiceImpl])
@@ -127,8 +127,7 @@ class HelpToSaveServiceImpl @Inject() (helpToSaveProxyConnector: HelpToSaveProxy
 
         response.status match {
           case Status.OK =>
-            val result = response.parseJsonWithoutLoggingBody[PayePersonalDetails]
-            result match {
+            response.parseJsonWithoutLoggingBody[PayePersonalDetails].tap {
               case Left(e) =>
                 metrics.payePersonalDetailsErrorCounter.inc()
                 logger.warn(s"Could not parse JSON response from paye-personal-details, received 200 (OK): $e ${timeString(time)}", nino, additionalParams)
@@ -136,7 +135,6 @@ class HelpToSaveServiceImpl @Inject() (helpToSaveProxyConnector: HelpToSaveProxy
               case Right(_) =>
                 logger.debug(s"Call to check paye-personal-details successful, received 200 (OK) ${timeString(time)}", nino, additionalParams)
             }
-            result
 
           case other =>
             logger.warn(s"Call to paye-personal-details unsuccessful. Received unexpected status $other ${timeString(time)}", nino, additionalParams)

--- a/app/uk/gov/hmrc/helptosave/services/HelpToSaveService.scala
+++ b/app/uk/gov/hmrc/helptosave/services/HelpToSaveService.scala
@@ -128,14 +128,14 @@ class HelpToSaveServiceImpl @Inject() (helpToSaveProxyConnector: HelpToSaveProxy
         response.status match {
           case Status.OK =>
             val result = response.parseJsonWithoutLoggingBody[PayePersonalDetails]
-            result.fold({
-              e =>
+            result match {
+              case Left(e) =>
                 metrics.payePersonalDetailsErrorCounter.inc()
                 logger.warn(s"Could not parse JSON response from paye-personal-details, received 200 (OK): $e ${timeString(time)}", nino, additionalParams)
                 pagerDutyAlerting.alert("Could not parse JSON in the paye-personal-details response")
-            }, _ =>
-              logger.debug(s"Call to check paye-personal-details successful, received 200 (OK) ${timeString(time)}", nino, additionalParams)
-            )
+              case Right(_) =>
+                logger.debug(s"Call to check paye-personal-details successful, received 200 (OK) ${timeString(time)}", nino, additionalParams)
+            }
             result
 
           case other =>


### PR DESCRIPTION
An experimental refactor PR showing how we could structure the code with basic language constructs to make it easier to read and debug.

Reasons to use match instead of .fold`:
* Easy to confuse whether we're handling positive or negative case
* Difficult to compose with pattern matching
* Difficult to chain with `for` expressions which leads to nesting
* Easier to debug (easier to select the handling case, keeps the stack flat)

Reasons to use `for` instead of `.flatMap`/`.map`:
* Easier to debug (procedural-looking code)
* Encourages chaining (with EitherT)
* Less nesting

Reasons to use `.pipe` / `.tap`:
* Avoids creating unnecessary variables (restricts scope of values)
* Allows you to chain outside of monads