### PR TITLE
DLS-9402 | Fix partial accounts by introducing soft deletion of enrolments

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Application configuration allows following keys and corresponding values for man
   
 - Undo deletions
   ```json
-  [{"nino": "AE123456A", "docId": "65745f62533fa40f2b31f763"}, {"nino": "BE783456A", "docId": "65745f62533fa40f2b31f764"}]
+  [{"nino": "AE123456A", "docID": "65745f62533fa40f2b31f763"}, {"nino": "BE783456A", "docID": "65745f62533fa40f2b31f764"}]
   ```
   
 Approach to rely on doc id puts a dependency on knowing which of the enrolments we want to undo deletion for and make it active.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Running and Testing
 Running
 -------
 
-Run `sbt run` on the terminal to start the service. The service runs on port 7004 by default.
+Run `sbt run` on the terminal to start the service. The service runs on port 7001 by default.
 
 Unit tests
 ----------
@@ -153,8 +153,36 @@ Endpoints
 | /paye-personal-details       | GET  | Gets user information for HTS |
 | /validate-bank-details       | POST | Checks that bank details are valid |
 
+Managing Deletions
+==================
+Service currently doesn't have a handler to manage deletions on back of account deletions in downstream systems, THALER.
+This causes problems when the user tries to create another account but is marked as not eligible due to account being still
+active in HTS system.
+
+Till a better solution is in place to manage these deletions automatically, service currently supports this via soft deletions.
+This is driven by config, where a list of user NINOs are configured for either deletion or undoing of any previous deletions.
+
+These config entries are read during application startup and processed accordingly. Processing is done by marking the enrolments
+as soft-delete using a `deleteFlag` field on document. This approach is ideal than prefixing NINOs, as it's not ideal to mutate 
+keys for soft deletions, and should instead rely on fields specifically set aside for this. For audit purposes, we also log the
+date on which has been taken under a field called `deleteDate`.
+
+Application configuration allows following keys and corresponding values for managing deletions
+
+- Deletions
+  ```json
+  [{"nino": "AE123456A"}, {"nino": "BE783456A"}]
+  ```
+  
+- Undo deletions
+  ```json
+  [{"nino": "AE123456A", "docId": "65745f62533fa40f2b31f763"}, {"nino": "BE783456A", "docId": "65745f62533fa40f2b31f764"}]
+  ```
+  
+Approach to rely on doc id puts a dependency on knowing which of the enrolments we want to undo deletion for and make it active.
+This step of relying on access to live data is anyway needed with other alternate approaches (like prefixing NINOs), as prefix
+doesn't have context on the enrolment.
+
 License 
 =======
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html")
-
-

--- a/app/uk/gov/hmrc/helptosave/actors/UCThresholdConnectorProxyActor.scala
+++ b/app/uk/gov/hmrc/helptosave/actors/UCThresholdConnectorProxyActor.scala
@@ -38,7 +38,6 @@ class UCThresholdConnectorProxyActor(dESConnector: DESConnector, pagerDutyAlerti
 
       val additionalParams = "DesCorrelationId" -> response.desCorrelationId
 
-
       response.status match {
         case Status.OK =>
           val result = response.parseJson[UCThreshold]

--- a/app/uk/gov/hmrc/helptosave/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/helptosave/config/AppConfig.scala
@@ -18,11 +18,16 @@ package uk.gov.hmrc.helptosave.config
 
 import configs.syntax._
 import com.google.inject.Singleton
+import com.typesafe.config.ConfigRenderOptions
+
 import javax.inject.Inject
 import play.api.Mode
+import play.api.libs.json.Json
 import play.api.{Configuration, Environment}
+import uk.gov.hmrc.helptosave.models.NINODeletionConfig
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.FiniteDuration
 
 @Singleton
@@ -47,4 +52,9 @@ class AppConfig @Inject() (val runModeConfiguration: Configuration,
 
   val barsUrl: String = servicesConfig.baseUrl("bank-account-reputation")
 
+  val ninoDeletionConfig: String => Seq[NINODeletionConfig] = (configSuffix: String) => {
+    runModeConfiguration.underlying.getObjectList(s"enrolment.$configSuffix").asScala.flatMap(config => {
+      Json.parse(config.render(ConfigRenderOptions.concise())).validate[NINODeletionConfig].asOpt
+    }).toSeq
+  }
 }

--- a/app/uk/gov/hmrc/helptosave/controllers/EnrolmentBehaviour.scala
+++ b/app/uk/gov/hmrc/helptosave/controllers/EnrolmentBehaviour.scala
@@ -48,14 +48,16 @@ trait EnrolmentBehaviour {
                             itmpFlag = true,
                             createAccountRequest.eligibilityReason,
                             createAccountRequest.source,
-                            accountNumber)
+                            accountNumber,
+                            None)
     } else {
       for {
         _ <- enrolmentStore.insert(createAccountRequest.payload.nino,
                                    itmpFlag = false,
                                    createAccountRequest.eligibilityReason,
                                    createAccountRequest.source,
-                                   accountNumber)
+                                   accountNumber,
+                                   None)
         _ <- setITMPFlagAndUpdateMongo(createAccountRequest.payload.nino)
       } yield ()
     }

--- a/app/uk/gov/hmrc/helptosave/controllers/HelpToSaveController.scala
+++ b/app/uk/gov/hmrc/helptosave/controllers/HelpToSaveController.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.helptosave.controllers
 
-import akka.http.scaladsl.model.HttpResponse
-import cats.data.EitherT
 import cats.instances.future._
 import cats.instances.int._
 import cats.instances.string._
@@ -29,8 +27,8 @@ import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.helptosave.audit.HTSAuditor
 import uk.gov.hmrc.helptosave.config.AppConfig
 import uk.gov.hmrc.helptosave.connectors.HelpToSaveProxyConnector
-import uk.gov.hmrc.helptosave.models.register.CreateAccountRequest
 import uk.gov.hmrc.helptosave.models._
+import uk.gov.hmrc.helptosave.models.register.CreateAccountRequest
 import uk.gov.hmrc.helptosave.repo.{EmailStore, EnrolmentStore}
 import uk.gov.hmrc.helptosave.services.{BarsService, HelpToSaveService, UserCapService}
 import uk.gov.hmrc.helptosave.util.JsErrorOps._
@@ -38,7 +36,7 @@ import uk.gov.hmrc.helptosave.util.Logging._
 import uk.gov.hmrc.helptosave.util.{LogMessageTransformer, toFuture}
 import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 
 class HelpToSaveController @Inject() (val enrolmentStore:         EnrolmentStore,

--- a/app/uk/gov/hmrc/helptosave/metrics/Metrics.scala
+++ b/app/uk/gov/hmrc/helptosave/metrics/Metrics.scala
@@ -58,6 +58,14 @@ class Metrics @Inject() (metrics: com.kenshoo.play.metrics.Metrics) {
 
   val enrolmentStoreUpdateErrorCounter: Counter = counter("backend.enrolment-store-update-error.count")
 
+  val enrolmentStoreDeleteErrorCounter: Boolean => Counter = (revertSoftDelete: Boolean) => {
+    if (revertSoftDelete) {
+      counter("backend.enrolment-store-undo-delete-error.count")
+    } else {
+      counter("backend.enrolment-store-delete-error.count")
+    }
+  }
+
   val payePersonalDetailsTimer: Timer = timer("backend.paye-personal-details.time")
 
   val payePersonalDetailsErrorCounter: Counter = counter("backend.paye-personal-details-error.count")

--- a/app/uk/gov/hmrc/helptosave/models/NINODeletionConfig.scala
+++ b/app/uk/gov/hmrc/helptosave/models/NINODeletionConfig.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.models
+
+import org.bson.types.ObjectId
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{Format, __}
+import uk.gov.hmrc.helptosave.util.NINO
+import uk.gov.hmrc.mongo.play.json.formats.MongoFormats.Implicits.objectIdFormat
+
+case class NINODeletionConfig(nino: NINO, docID: Option[ObjectId] = None)
+
+object NINODeletionConfig {
+  implicit val format: Format[NINODeletionConfig] = {
+    ((__ \ "nino").format[String] and (__ \ "docID").formatNullable[ObjectId]) (
+      NINODeletionConfig.apply, deletionConfig => (deletionConfig.nino, deletionConfig.docID)
+    )
+  }
+}

--- a/app/uk/gov/hmrc/helptosave/modules/NINODeletionModule.scala
+++ b/app/uk/gov/hmrc/helptosave/modules/NINODeletionModule.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.modules
+
+import com.google.inject.AbstractModule
+import uk.gov.hmrc.helptosave.services.ApplicationStart
+
+class NINODeletionModule extends AbstractModule {
+  override def configure(): Unit = {
+    bind(classOf[ApplicationStart]).asEagerSingleton()
+  }
+}

--- a/app/uk/gov/hmrc/helptosave/repo/EnrolmentStore.scala
+++ b/app/uk/gov/hmrc/helptosave/repo/EnrolmentStore.scala
@@ -19,12 +19,14 @@ package uk.gov.hmrc.helptosave.repo
 import cats.data.EitherT
 import com.google.inject.{ImplementedBy, Inject, Singleton}
 import com.mongodb.client.model.ReturnDocument
-import org.mongodb.scala.model.Filters.regex
+import org.bson.types.ObjectId
+import org.mongodb.scala.model.Filters.{and, empty, exists, in, or, regex}
 import org.mongodb.scala.model.Indexes.ascending
-import org.mongodb.scala.model.{FindOneAndUpdateOptions, IndexModel, IndexOptions, Updates}
+import org.mongodb.scala.model.{BulkWriteOptions, Filters, FindOneAndUpdateOptions, IndexModel, IndexOptions, UpdateOneModel, UpdateOptions, Updates}
 import play.api.Logging
 import play.api.libs.json._
 import uk.gov.hmrc.helptosave.metrics.Metrics
+import uk.gov.hmrc.helptosave.models.NINODeletionConfig
 import uk.gov.hmrc.helptosave.models.account.AccountNumber
 import uk.gov.hmrc.helptosave.repo.EnrolmentStore.{Enrolled, NotEnrolled, Status}
 import uk.gov.hmrc.helptosave.repo.MongoEnrolmentStore.EnrolmentData
@@ -34,6 +36,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 
+import java.time.LocalDateTime
 import scala.concurrent.{ExecutionContext, Future}
 
 @ImplementedBy(classOf[MongoEnrolmentStore])
@@ -43,11 +46,13 @@ trait EnrolmentStore {
 
   def get(nino: NINO)(implicit hc: HeaderCarrier): EitherT[Future, String, Status]
 
+  def updateDeleteFlag(ninosDeletionConfig: Seq[NINODeletionConfig], revertSoftDelete: Boolean = false): EitherT[Future, String, Unit]
+
   def updateItmpFlag(nino: NINO, itmpFlag: Boolean)(implicit hc: HeaderCarrier): EitherT[Future, String, Unit]
 
   def updateWithAccountNumber(nino: NINO, accountNumber: String)(implicit hc: HeaderCarrier): EitherT[Future, String, Unit]
 
-  def insert(nino: NINO, itmpFlag: Boolean, eligibilityReason: Option[Int], source: String, accountNumber: Option[String])(implicit hc: HeaderCarrier): EitherT[Future, String, Unit]
+  def insert(nino: NINO, itmpFlag: Boolean, eligibilityReason: Option[Int], source: String, accountNumber: Option[String], deleteFlag: Option[Boolean])(implicit hc: HeaderCarrier): EitherT[Future, String, Unit]
 
   def getAccountNumber(nino: NINO)(implicit hc: HeaderCarrier): EitherT[Future, String, AccountNumber]
 
@@ -79,14 +84,12 @@ object EnrolmentStore {
         case EnrolmentStatusJSON(false, _)   => NotEnrolled
       }
     }
-
   }
-
 }
 
 @Singleton
-class MongoEnrolmentStore @Inject() (mongo:   MongoComponent,
-                                     metrics: Metrics)(implicit ec: ExecutionContext)
+class MongoEnrolmentStore @Inject() (val mongo: MongoComponent,
+                                     metrics:   Metrics)(implicit ec: ExecutionContext)
   extends PlayMongoRepository[EnrolmentData](
     mongoComponent = mongo,
     collectionName = "enrolments",
@@ -101,7 +104,8 @@ class MongoEnrolmentStore @Inject() (mongo:   MongoComponent,
                              eligibilityReason: Option[Int],
                              source:            String,
                              itmpFlag:          Boolean,
-                             accountNumber:     Option[String])(implicit ec: ExecutionContext): Future[Unit] = {
+                             accountNumber:     Option[String],
+                             deleteFlag:        Option[Boolean])(implicit ec: ExecutionContext): Future[Unit] = {
 
     collection.insertOne(
       EnrolmentData(
@@ -109,7 +113,8 @@ class MongoEnrolmentStore @Inject() (mongo:   MongoComponent,
         itmpHtSFlag       = itmpFlag,
         eligibilityReason = eligibilityReason,
         source            = Some(source),
-        accountNumber     = accountNumber)
+        accountNumber     = accountNumber,
+        deleteFlag        = deleteFlag)
     ).toFuture().map(_ => ())
 
   }
@@ -121,6 +126,33 @@ class MongoEnrolmentStore @Inject() (mongo:   MongoComponent,
       options = FindOneAndUpdateOptions().bypassDocumentValidation(false).returnDocument(ReturnDocument.AFTER)
     ).toFutureOption()
 
+  }
+
+  private[repo] def doUpdateDeleteFlag(ninosDeletionConfig: Seq[NINODeletionConfig], revertSoftDelete: Boolean = false)(implicit ec: ExecutionContext): EitherT[Future, String, Unit] = {
+
+    val updateModels: Seq[UpdateOneModel[Nothing]] = ninosDeletionConfig.map(config => {
+      val filter = if (!revertSoftDelete) regex("nino", getRegex(config.nino)) else {
+        and(
+          regex("nino", getRegex(config.nino)),
+          config.docID.fold(empty())(id => Filters.eq("_id", id)),
+          Filters.eq("deleteFlag", true)
+        )
+      }
+
+      UpdateOneModel(
+        filter        = filter,
+        update        = Updates.combine(Updates.set("deleteFlag", !revertSoftDelete), Updates.set("deleteDate", LocalDateTime.now())),
+        updateOptions = UpdateOptions().bypassDocumentValidation(false)
+      )
+    })
+
+    EitherT[Future, String, Unit]({
+      collection.bulkWrite(updateModels, BulkWriteOptions().ordered(false)).toFuture().map { _ =>
+        Right(())
+      }.recover {
+        case e => Left(s"Failed to mark NINOs, ${ninosDeletionConfig.map(_.nino)}, as soft-delete : ${e.getMessage}")
+      }
+    })
   }
 
   private[repo] def persistAccountNumber(nino: NINO, accountNumber: String)(implicit ec: ExecutionContext): Future[Option[EnrolmentData]] =
@@ -135,17 +167,26 @@ class MongoEnrolmentStore @Inject() (mongo:   MongoComponent,
       {
         val timerContext = metrics.enrolmentStoreGetTimer.time()
 
-        collection.find(regex("nino", getRegex(nino))).toFuture().map { res =>
-          timerContext.stop()
+        collection.find(
+          and(
+            regex("nino", getRegex(nino)),
+            or(
+              exists("deleteFlag", exists = false),
+              Filters.eq("deleteFlag", false)
+            )
+          )
+        ).toFuture().map { res =>
 
-          Right(res.headOption.fold[Status](NotEnrolled)(data => Enrolled(data.itmpHtSFlag)))
-        }.recover {
-          case e =>
             timerContext.stop()
-            metrics.enrolmentStoreGetErrorCounter.inc()
 
-            Left(s"For NINO [$nino]: Could not read from enrolment store: ${e.getMessage}")
-        }
+            Right(res.headOption.fold[Status](NotEnrolled)(data => Enrolled(data.itmpHtSFlag)))
+          }.recover {
+            case e =>
+              timerContext.stop()
+              metrics.enrolmentStoreGetErrorCounter.inc()
+
+              Left(s"For NINO [$nino]: Could not read from enrolment store: ${e.getMessage}")
+          }
       })
 
   override def updateItmpFlag(nino: NINO, itmpFlag: Boolean)(implicit hc: HeaderCarrier): EitherT[Future, String, Unit] = {
@@ -168,8 +209,34 @@ class MongoEnrolmentStore @Inject() (mongo:   MongoComponent,
 
           Left(s"Failed to write to enrolments store: ${e.getMessage}")
       }
-    }
-    )
+    })
+  }
+
+  override def updateDeleteFlag(ninosDeletionConfig: Seq[NINODeletionConfig], revertSoftDelete: Boolean): EitherT[Future, String, Unit] = {
+    EitherT[Future, String, Unit]({
+      val timerContext = metrics.enrolmentStoreGetTimer.time()
+
+      val ninos = ninosDeletionConfig.map(_.nino)
+
+      collection.find(in("nino", ninos: _*)).map(_.nino).toFuture().map(
+        availableNINOs => {
+          ninos.diff(availableNINOs.distinct)
+        }
+      ).map { result =>
+          if (result.nonEmpty) {
+            metrics.enrolmentStoreDeleteErrorCounter(revertSoftDelete).inc()
+            Left(s"Following requested NINOs not found in system : ${ninosDeletionConfig.map(_.nino)}")
+          } else {
+            Right(())
+          }
+        }.recover {
+          case e =>
+            timerContext.stop()
+            metrics.enrolmentStoreDeleteErrorCounter(revertSoftDelete).inc()
+
+            Left(s"Search for NINOs failed: ${e.getMessage}")
+        }
+    }).map(_ => doUpdateDeleteFlag(ninosDeletionConfig, revertSoftDelete))
   }
 
   override def updateWithAccountNumber(nino: NINO, accountNumber: String)(implicit hc: HeaderCarrier): EitherT[Future, String, Unit] = {
@@ -192,17 +259,17 @@ class MongoEnrolmentStore @Inject() (mongo:   MongoComponent,
 
           Left(s"Failed to write to enrolments store: ${e.getMessage}")
       }
-    }
-    )
+    })
   }
 
   override def insert(nino:              NINO,
                       itmpFlag:          Boolean,
                       eligibilityReason: Option[Int],
                       source:            String,
-                      accountNumber:     Option[String])(implicit hc: HeaderCarrier): EitherT[Future, String, Unit] =
+                      accountNumber:     Option[String],
+                      deleteFlag:        Option[Boolean])(implicit hc: HeaderCarrier): EitherT[Future, String, Unit] =
     EitherT(
-      doInsert(nino, eligibilityReason, source, itmpFlag, accountNumber)
+      doInsert(nino, eligibilityReason, source, itmpFlag, accountNumber, deleteFlag)
         .map[Either[String, Unit]] { writeResult => Right(())
         }.recover {
           case e =>
@@ -233,9 +300,10 @@ object MongoEnrolmentStore {
 
   private[repo] case class EnrolmentData(nino:              String,
                                          itmpHtSFlag:       Boolean,
-                                         eligibilityReason: Option[Int]    = None,
-                                         source:            Option[String] = None,
-                                         accountNumber:     Option[String] = None)
+                                         eligibilityReason: Option[Int]     = None,
+                                         source:            Option[String]  = None,
+                                         accountNumber:     Option[String]  = None,
+                                         deleteFlag:        Option[Boolean] = None)
 
   private[repo] object EnrolmentData {
     implicit val ninoFormat: Format[EnrolmentData] = Json.format[EnrolmentData]

--- a/app/uk/gov/hmrc/helptosave/repo/EnrolmentStore.scala
+++ b/app/uk/gov/hmrc/helptosave/repo/EnrolmentStore.scala
@@ -47,7 +47,7 @@ trait EnrolmentStore {
 
   def get(nino: NINO)(implicit hc: HeaderCarrier): EitherT[Future, String, Status]
 
-  def updateDeleteFlag(ninosDeletionConfig: Seq[NINODeletionConfig], revertSoftDelete: Boolean = false): EitherT[Future, String, Seq[EnrolmentData]]
+  def updateDeleteFlag(ninosDeletionConfig: Seq[NINODeletionConfig], revertSoftDelete: Boolean = false): EitherT[Future, String, Seq[NINODeletionConfig]]
 
   def updateItmpFlag(nino: NINO, itmpFlag: Boolean)(implicit hc: HeaderCarrier): EitherT[Future, String, Unit]
 
@@ -213,7 +213,7 @@ class MongoEnrolmentStore @Inject() (val mongo: MongoComponent,
     })
   }
 
-  override def updateDeleteFlag(ninosDeletionConfig: Seq[NINODeletionConfig], revertSoftDelete: Boolean): EitherT[Future, String, Seq[EnrolmentData]] = {
+  override def updateDeleteFlag(ninosDeletionConfig: Seq[NINODeletionConfig], revertSoftDelete: Boolean): EitherT[Future, String, Seq[NINODeletionConfig]] = {
     val timerContext = metrics.enrolmentStoreGetTimer.time()
 
     val filter = or(
@@ -244,6 +244,7 @@ class MongoEnrolmentStore @Inject() (val mongo: MongoComponent,
       }
       .pipe(EitherT(_))
       .flatMap(doUpdateDeleteFlag(_, revertSoftDelete))
+      .map(_.map(enrolment => NINODeletionConfig(enrolment.nino, enrolment._id)))
   }
 
   override def updateWithAccountNumber(nino: NINO, accountNumber: String)(implicit hc: HeaderCarrier): EitherT[Future, String, Unit] = {

--- a/app/uk/gov/hmrc/helptosave/services/ApplicationStart.scala
+++ b/app/uk/gov/hmrc/helptosave/services/ApplicationStart.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.services
+
+import play.api.Logging
+import uk.gov.hmrc.helptosave.config.AppConfig
+import uk.gov.hmrc.helptosave.models.NINODeletionConfig
+import uk.gov.hmrc.helptosave.repo.EnrolmentStore
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+@Singleton
+class ApplicationStart @Inject() (appConfig: AppConfig, enrolmentStore: EnrolmentStore, executionContext: ExecutionContext) extends Logging {
+
+  implicit val ec: ExecutionContext = executionContext
+
+  val ninosToDelete: Seq[NINODeletionConfig] = appConfig.ninoDeletionConfig("delete-ninos")
+  if (ninosToDelete.nonEmpty) {
+    enrolmentStore.updateDeleteFlag(ninosToDelete).value.onComplete {
+      case Success(Right(_))       => logger.info(s"Successfully deleted list of NINOs : $ninosToDelete")
+      case Success(Left(errorMsg)) => logger.error(errorMsg)
+      case Failure(ex)             => logger.error(s"Failed to delete configured list of NINOs: $ninosToDelete", ex)
+    }
+  }
+
+  val ninosToUndoDeletion: Seq[NINODeletionConfig] = appConfig.ninoDeletionConfig("undo-delete-ninos")
+  if (ninosToUndoDeletion.nonEmpty) {
+    enrolmentStore.updateDeleteFlag(ninosToUndoDeletion, revertSoftDelete = true).value.onComplete {
+      case Success(Right(_))       => logger.info(s"Successfully undid deletion of NINOs, $ninosToUndoDeletion")
+      case Success(Left(errorMsg)) => logger.error(errorMsg)
+      case Failure(ex)             => logger.error(s"Failed to undo deletion of of NINOs: $ninosToUndoDeletion", ex)
+    }
+  }
+}

--- a/app/uk/gov/hmrc/helptosave/services/ApplicationStart.scala
+++ b/app/uk/gov/hmrc/helptosave/services/ApplicationStart.scala
@@ -17,23 +17,36 @@
 package uk.gov.hmrc.helptosave.services
 
 import play.api.Logging
+import play.api.libs.json.Json
+import uk.gov.hmrc.helptosave.audit.HTSAuditor
 import uk.gov.hmrc.helptosave.config.AppConfig
 import uk.gov.hmrc.helptosave.models.NINODeletionConfig
 import uk.gov.hmrc.helptosave.repo.EnrolmentStore
+import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 @Singleton
-class ApplicationStart @Inject() (appConfig: AppConfig, enrolmentStore: EnrolmentStore, executionContext: ExecutionContext) extends Logging {
+class ApplicationStart @Inject() (appConfig:        AppConfig,
+                                  enrolmentStore:   EnrolmentStore,
+                                  executionContext: ExecutionContext,
+                                  audit:            HTSAuditor) extends Logging {
 
   implicit val ec: ExecutionContext = executionContext
 
   val ninosToDelete: Seq[NINODeletionConfig] = appConfig.ninoDeletionConfig("delete-ninos")
   if (ninosToDelete.nonEmpty) {
     enrolmentStore.updateDeleteFlag(ninosToDelete).value.onComplete {
-      case Success(Right(_))       => logger.info(s"Successfully deleted list of NINOs : $ninosToDelete")
+      case Success(Right(deletedAccounts)) =>
+        val ninos = deletedAccounts.map(_.nino).toList
+        audit.auditConnector.sendExtendedEvent(ExtendedDataEvent(
+          appConfig.appName,
+          "AccountsDeleted",
+          detail = Json.toJson(ninos),
+        ))
+        logger.info(s"Successfully deleted list of NINOs: " + ninos.mkString(", "))
       case Success(Left(errorMsg)) => logger.error(errorMsg)
       case Failure(ex)             => logger.error(s"Failed to delete configured list of NINOs: $ninosToDelete", ex)
     }
@@ -42,7 +55,14 @@ class ApplicationStart @Inject() (appConfig: AppConfig, enrolmentStore: Enrolmen
   val ninosToUndoDeletion: Seq[NINODeletionConfig] = appConfig.ninoDeletionConfig("undo-delete-ninos")
   if (ninosToUndoDeletion.nonEmpty) {
     enrolmentStore.updateDeleteFlag(ninosToUndoDeletion, revertSoftDelete = true).value.onComplete {
-      case Success(Right(_))       => logger.info(s"Successfully undid deletion of NINOs, $ninosToUndoDeletion")
+      case Success(Right(undeletedAccounts)) =>
+        val ninos = undeletedAccounts.map(_.nino).toList
+        audit.auditConnector.sendExtendedEvent(ExtendedDataEvent(
+          appConfig.appName,
+          "AccountsUndeleted",
+          detail = Json.toJson(ninos),
+        ))
+        logger.info(s"Successfully undid deletion of NINOs: " + ninos.mkString(", "))
       case Success(Left(errorMsg)) => logger.error(errorMsg)
       case Failure(ex)             => logger.error(s"Failed to undo deletion of of NINOs: $ninosToUndoDeletion", ex)
     }

--- a/app/uk/gov/hmrc/helptosave/services/ApplicationStart.scala
+++ b/app/uk/gov/hmrc/helptosave/services/ApplicationStart.scala
@@ -40,13 +40,8 @@ class ApplicationStart @Inject() (appConfig:        AppConfig,
   if (ninosToDelete.nonEmpty) {
     enrolmentStore.updateDeleteFlag(ninosToDelete).value.onComplete {
       case Success(Right(deletedAccounts)) =>
-        val ninos = deletedAccounts.map(_.nino).toList
-        audit.auditConnector.sendExtendedEvent(ExtendedDataEvent(
-          appConfig.appName,
-          "AccountsDeleted",
-          detail = Json.toJson(ninos),
-        ))
-        logger.info(s"Successfully deleted list of NINOs: " + ninos.mkString(", "))
+        publishAuditEventForNINOs("AccountsDeleted", deletedAccounts)
+        logger.info(s"Successfully deleted list of NINOs: $ninosToDelete")
       case Success(Left(errorMsg)) => logger.error(errorMsg)
       case Failure(ex)             => logger.error(s"Failed to delete configured list of NINOs: $ninosToDelete", ex)
     }
@@ -56,15 +51,22 @@ class ApplicationStart @Inject() (appConfig:        AppConfig,
   if (ninosToUndoDeletion.nonEmpty) {
     enrolmentStore.updateDeleteFlag(ninosToUndoDeletion, revertSoftDelete = true).value.onComplete {
       case Success(Right(undeletedAccounts)) =>
-        val ninos = undeletedAccounts.map(_.nino).toList
-        audit.auditConnector.sendExtendedEvent(ExtendedDataEvent(
-          appConfig.appName,
-          "AccountsUndeleted",
-          detail = Json.toJson(ninos),
-        ))
-        logger.info(s"Successfully undid deletion of NINOs: " + ninos.mkString(", "))
+        publishAuditEventForNINOs("AccountsUndeleted", undeletedAccounts)
+        logger.info(s"Successfully undid deletion of NINOs: $ninosToUndoDeletion")
       case Success(Left(errorMsg)) => logger.error(errorMsg)
       case Failure(ex)             => logger.error(s"Failed to undo deletion of of NINOs: $ninosToUndoDeletion", ex)
     }
+  }
+
+  private def publishAuditEventForNINOs(auditType: String, managedConfigs: Seq[NINODeletionConfig]) = {
+    val ninos = managedConfigs.map(enrolment => Json.obj(
+      "nino" -> enrolment.nino,
+      "docId" -> enrolment.docID.map(_.toHexString)
+    )).toList
+    audit.auditConnector.sendExtendedEvent(ExtendedDataEvent(
+      appConfig.appName,
+      auditType,
+      detail = Json.toJson(ninos),
+    ))
   }
 }

--- a/app/uk/gov/hmrc/helptosave/services/HelpToSaveService.scala
+++ b/app/uk/gov/hmrc/helptosave/services/HelpToSaveService.scala
@@ -16,31 +16,27 @@
 
 package uk.gov.hmrc.helptosave.services
 
-import java.util.UUID
-
+import akka.pattern.ask
 import cats.data.EitherT
-import cats.syntax.eq._
-import cats.instances.int._
 import cats.instances.future._
 import com.google.inject.{ImplementedBy, Inject, Singleton}
-import uk.gov.hmrc.helptosave.audit.HTSAuditor
-import uk.gov.hmrc.helptosave.connectors.{DESConnector, HelpToSaveProxyConnector}
-import uk.gov.hmrc.helptosave.models._
-import uk.gov.hmrc.helptosave.modules.ThresholdManagerProvider
-import uk.gov.hmrc.helptosave.util.Logging._
-import uk.gov.hmrc.helptosave.util.{LogMessageTransformer, Logging, NINO, PagerDutyAlerting, Result, maskNino}
-import uk.gov.hmrc.http.HeaderCarrier
 import play.api.http.Status
-import akka.pattern.ask
 import play.mvc.Http.Status.{FORBIDDEN, OK}
 import uk.gov.hmrc.helptosave.actors.UCThresholdManager.{GetThresholdValue, GetThresholdValueResponse}
+import uk.gov.hmrc.helptosave.audit.HTSAuditor
 import uk.gov.hmrc.helptosave.config.AppConfig
+import uk.gov.hmrc.helptosave.connectors.{DESConnector, HelpToSaveProxyConnector}
 import uk.gov.hmrc.helptosave.metrics.Metrics
-import uk.gov.hmrc.helptosave.util.Time.nanosToPrettyString
+import uk.gov.hmrc.helptosave.models._
+import uk.gov.hmrc.helptosave.modules.ThresholdManagerProvider
 import uk.gov.hmrc.helptosave.util.HeaderCarrierOps.getApiCorrelationId
 import uk.gov.hmrc.helptosave.util.HttpResponseOps._
-import uk.gov.hmrc.helptosave.util.toFuture
+import uk.gov.hmrc.helptosave.util.Logging._
+import uk.gov.hmrc.helptosave.util.Time.nanosToPrettyString
+import uk.gov.hmrc.helptosave.util.{LogMessageTransformer, Logging, NINO, PagerDutyAlerting, Result, maskNino, toFuture}
+import uk.gov.hmrc.http.HeaderCarrier
 
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
@@ -164,7 +160,6 @@ class HelpToSaveServiceImpl @Inject() (helpToSaveProxyConnector: HelpToSaveProxy
         val time = timerContext.stop()
 
         val additionalParams = "DesCorrelationId" -> response.desCorrelationId
-
 
         response.status match {
           case Status.OK =>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,6 +54,9 @@ play.modules.enabled += "uk.gov.hmrc.helptosave.modules.UCThresholdModule"
 # Starts up the Eligibility Stats Actor
 play.modules.enabled += "uk.gov.hmrc.helptosave.modules.EligibilityStatsModule"
 
+# Custom module to manage deletions/undo-deletions of enrolments, given list of NINOs
+play.modules.enabled += "uk.gov.hmrc.helptosave.modules.NINODeletionModule"
+
 play.filters.disabled += play.filters.csrf.CSRFFilter
 play.filters.disabled += play.filters.hosts.AllowedHostsFilter
 
@@ -248,3 +251,8 @@ stride {
     update-time       = "00:00"
     update-time-delay = "30 minutes"
   }
+
+enrolment {
+  delete-ninos = []
+  undo-delete-ninos = []
+}

--- a/it/helpers/EnrolmentStoreRepoHelper.scala
+++ b/it/helpers/EnrolmentStoreRepoHelper.scala
@@ -20,7 +20,10 @@ trait EnrolmentStoreRepoHelper {
                           itmpFlag: Boolean,
                           eligibilityReason: Option[Int],
                           source: String,
-                          accountNumber: Option[String])(implicit hc: HeaderCarrier) = await(enrolmentStoreRepository.insert(nino, itmpFlag, eligibilityReason, source, accountNumber).value)
+                          accountNumber: Option[String],
+                          deleteFlag: Option[Boolean] = None)(implicit hc: HeaderCarrier) = {
+    await(enrolmentStoreRepository.insert(nino, itmpFlag, eligibilityReason, source, accountNumber, deleteFlag).value)
+  }
 
   def deleteAllEnrolmentData() = await(enrolmentStoreRepository.collection.deleteMany(Filters.empty()).toFuture())
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.jcenterRepo
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.14.0")
+addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "3.15.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "2.2.0")
 addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.8.18")
 addSbtPlugin("org.scoverage"      %% "sbt-scoverage"          % "1.9.3")

--- a/test/uk/gov/hmrc/helptosave/repo/MongoEnrolmentStoreSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/repo/MongoEnrolmentStoreSpec.scala
@@ -16,12 +16,19 @@
 
 package uk.gov.hmrc.helptosave.repo
 
+import org.bson.types.ObjectId
+import org.mongodb.scala.model.Filters
 import org.scalatest.BeforeAndAfterEach
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{Format, Json, __}
+import uk.gov.hmrc.helptosave.models.NINODeletionConfig
 import uk.gov.hmrc.helptosave.repo.EnrolmentStore.{Enrolled, NotEnrolled, Status}
 import uk.gov.hmrc.helptosave.util.NINO
 import uk.gov.hmrc.helptosave.utils.TestSupport
 import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.CollectionFactory
 import uk.gov.hmrc.mongo.test.MongoSupport
+import uk.gov.hmrc.mongo.play.json.formats.MongoFormats.Implicits.objectIdFormat
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -40,21 +47,25 @@ class MongoEnrolmentStoreSpec extends TestSupport with MongoSupport with BeforeA
   def newMongoEnrolmentStore(mongoComponent: MongoComponent) =
     new MongoEnrolmentStore(mongoComponent, mockMetrics)
 
+  private val duration: FiniteDuration = 15.seconds
+
   def create(nino: NINO, itmpNeedsUpdate: Boolean, eligibilityReason: Option[Int], channel: String, store: MongoEnrolmentStore,
-             accountNumber: Option[String]): Either[String, Unit] =
-    Await.result(store.insert(nino, itmpNeedsUpdate, eligibilityReason, channel, accountNumber).value, 15.second)
+             accountNumber: Option[String], deleteFlag: Option[Boolean]): Either[String, Unit] =
+    Await.result(store.insert(nino, itmpNeedsUpdate, eligibilityReason, channel, accountNumber, deleteFlag).value, duration)
+
+  def updateDeleteFlag(ninos: Seq[NINODeletionConfig], revertSoftDelete: Boolean, store: MongoEnrolmentStore) = {
+    Await.result(store.updateDeleteFlag(ninos, revertSoftDelete).value, duration)
+  }
 
   "The MongoEnrolmentStore" when {
-
     "creating" must {
-
       "create a new record in the db when inserted" in {
-        val nino = randomNINO()
-        val store = repository
-        val create1 = create(nino, true, Some(7), "online", store, Some(accountNumber))
+        val create1 = create(randomNINO(), true, Some(7), "online", repository, Some(accountNumber), None)
         create1 shouldBe Right(())
       }
     }
+
+      def get(nino: NINO, store: MongoEnrolmentStore): Either[String, Status] = Await.result(store.get(nino).value, duration)
 
     "updating" must {
 
@@ -63,25 +74,21 @@ class MongoEnrolmentStoreSpec extends TestSupport with MongoSupport with BeforeA
 
       "update the mongodb collection" in {
         val nino = randomNINO()
-        val store = repository
-        create(nino, false, Some(7), "online", store, Some(accountNumber)) shouldBe Right(())
-        update(nino, true, store) shouldBe Right(())
+        create(nino, false, Some(7), "online", repository, Some(accountNumber), None) shouldBe Right(())
+        update(nino, true, repository) shouldBe Right(())
       }
 
       "return an error" when {
 
         "the future returned by mongo fails" in {
-          val nino = randomNINO()
-          val store = repository
-          update(nino, false, store).isLeft shouldBe true
+          update(randomNINO(), false, repository).isLeft shouldBe true
         }
       }
 
       "update the enrolment when a different nino suffix is used of an existing user" in {
         val nino = "AE123456A"
-        val store = repository
-        create(nino, false, Some(7), "online", store, Some(accountNumber)) shouldBe Right(())
-        update(ninoDifferentSuffix, true, store) shouldBe Right(())
+        create(nino, false, Some(7), "online", repository, Some(accountNumber), None) shouldBe Right(())
+        update(ninoDifferentSuffix, true, repository) shouldBe Right(())
       }
     }
 
@@ -92,33 +99,117 @@ class MongoEnrolmentStoreSpec extends TestSupport with MongoSupport with BeforeA
 
       "attempt to find the entry in the collection based on the input nino" in {
         val nino = randomNINO()
-        val store = repository
-        get(nino, store) shouldBe Right(NotEnrolled)
+        get(nino, repository) shouldBe Right(NotEnrolled)
       }
 
       "return an enrolled status if an entry is found" in {
         val nino = randomNINO()
         val store = repository
-        create(nino, true, Some(7), "online", store, Some(accountNumber)) shouldBe Right(())
+        create(nino, true, Some(7), "online", store, Some(accountNumber), None) shouldBe Right(())
         get(nino, store) shouldBe Right(Enrolled(true))
       }
 
       "return a not enrolled status if the entry is not found" in {
         val nino = randomNINO()
-        val store = repository
-        get(nino, store) shouldBe Right(NotEnrolled)
+        get(nino, repository) shouldBe Right(NotEnrolled)
       }
 
       "return an enrolled status when a different nino suffix is used of an existing user" in {
         val nino = "AE123456A"
         val store = repository
-        create(nino, true, Some(7), "online", store, Some(accountNumber)) shouldBe Right(())
+        create(nino, true, Some(7), "online", store, Some(accountNumber), None) shouldBe Right(())
         get(nino, store) shouldBe Right(Enrolled(true))
         get(ninoDifferentSuffix, store) shouldBe Right(Enrolled(true))
       }
 
+      "return as not enrolled if the entry is marked as delete" in {
+        val nino = "AE123456A"
+        val store = repository
+        create(nino, true, Some(7), "online", store, Some(accountNumber), Some(true)) shouldBe Right(())
+        get(nino, store) shouldBe Right(NotEnrolled)
+      }
+
     }
 
+    "soft-delete request " must {
+      "update enrolment documents with delete_flag set to true and delete_date populated when valid NINOs given" in {
+        val nino = "AE123456A"
+        val store = repository
+        create(nino, true, Some(7), "online", store, Some(accountNumber), None) shouldBe Right(())
+        get(nino, store) shouldBe Right(Enrolled(true))
+
+        updateDeleteFlag(Seq(NINODeletionConfig(nino)), false, store)
+        get(nino, store) shouldBe Right(NotEnrolled)
+      }
+
+      "not update enrolment documents when given NINOs are missing in system" in {
+        val nino = randomNINO()
+        updateDeleteFlag(Seq(NINODeletionConfig(nino)), revertSoftDelete = false, repository) shouldBe
+          Left(s"Following requested NINOs not found in system : List($nino)")
+      }
+
+      "to undo the action, must set delete_flag to false if already marked as delete" in {
+        val nino = "BE123456A"
+        val store = repository
+        create(nino, true, Some(7), "online", store, Some(accountNumber), Some(true)) shouldBe Right(())
+        get(nino, store) shouldBe Right(NotEnrolled)
+
+        updateDeleteFlag(Seq(NINODeletionConfig(nino)), true, store)
+        get(nino, store) shouldBe Right(Enrolled(true))
+      }
+
+      "to undo the action, must be a no-op when enrolment is not marked for delete" in {
+        val nino = "CE123456A"
+        val store = repository
+        create(nino, true, Some(7), "online", store, Some(accountNumber), Some(false)) shouldBe Right(())
+        get(nino, store) shouldBe Right(Enrolled(true))
+
+        updateDeleteFlag(Seq(NINODeletionConfig(nino)), true, store)
+        get(nino, store) shouldBe Right(Enrolled(true))
+      }
+
+      "to undo the action, must be a no-op when enrolment has delete_flag missing" in {
+        val nino = "DE123456A"
+        val store = repository
+        create(nino, true, Some(7), "online", store, Some(accountNumber), None) shouldBe Right(())
+        get(nino, store) shouldBe Right(Enrolled(true))
+
+        updateDeleteFlag(Seq(NINODeletionConfig(nino)), true, store)
+        get(nino, store) shouldBe Right(Enrolled(true))
+      }
+
+      "to undo the action, must set delete_flag to false for the given object id, if already marked as delete" in {
+        val nino = "EE123456A"
+        val store = repository
+        create(nino, true, Some(7), "online", store, Some(accountNumber), Some(true)) shouldBe Right(())
+        create(nino, true, Some(3), "online", store, Some(accountNumber), Some(true)) shouldBe Right(())
+        get(nino, store) shouldBe Right(NotEnrolled)
+
+        val collection = CollectionFactory.collection(store.mongo.database, "enrolments", Json.format[EnrolmentDocId])
+        val docIds = await(collection.find(Filters.eq("nino", nino)).map(_._id).toFuture())(duration)
+        val docIdToRevertDeletion = docIds.head
+
+        updateDeleteFlag(Seq(NINODeletionConfig(nino, Some(docIdToRevertDeletion))), revertSoftDelete = true, store) shouldBe Right(())
+
+        // only above executed doc id should be marked as eligible and other one still with soft-delete
+        val updatedDocs = await(collection.find(Filters.eq("nino", nino)).toFuture())(duration)
+        val (reverted, deleted) = updatedDocs.partition(_._id == docIdToRevertDeletion)
+
+        reverted.head.deleteFlag shouldBe false
+        deleted.head.deleteFlag shouldBe true
+        get(nino, store) shouldBe Right(Enrolled(true))
+      }
+    }
+  }
+
+  case class EnrolmentDocId(_id: ObjectId, nino: NINO, deleteFlag: Boolean)
+
+  object EnrolmentDocId {
+    implicit val format: Format[EnrolmentDocId] = {
+      ((__ \ "_id").format[ObjectId] and (__ \ "nino").format[String] and (__ \ "deleteFlag").format[Boolean]) (
+        EnrolmentDocId.apply, doc => (doc._id, doc.nino, doc.deleteFlag)
+      )
+    }
   }
 
 }

--- a/test/uk/gov/hmrc/helptosave/repo/MongoEnrolmentStoreSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/repo/MongoEnrolmentStoreSpec.scala
@@ -56,7 +56,6 @@ class MongoEnrolmentStoreSpec extends TestSupport with MongoSupport with BeforeA
 
   def updateDeleteFlag(ninos: Seq[NINODeletionConfig], revertSoftDelete: Boolean, store: MongoEnrolmentStore) = {
     Await.result(store.updateDeleteFlag(ninos, revertSoftDelete).value, duration)
-      .map(_.map(enrolment => NINODeletionConfig(enrolment.nino, enrolment._id)))
   }
 
   "The MongoEnrolmentStore" when {

--- a/test/uk/gov/hmrc/helptosave/utils/TestEnrolmentBehaviour.scala
+++ b/test/uk/gov/hmrc/helptosave/utils/TestEnrolmentBehaviour.scala
@@ -45,9 +45,10 @@ trait TestEnrolmentBehaviour extends TestSupport {
       .expects(nino, itmpFlag, *)
       .returning(EitherT.fromEither[Future](result))
 
-  def mockEnrolmentStoreInsert(nino: NINO, itmpFlag: Boolean, eligibilityReason: Option[Int], source: String, accountNumber: Option[String])(result: Either[String, Unit]): Unit =
-    (enrolmentStore.insert(_: NINO, _: Boolean, _: Option[Int], _: String, _: Option[String])(_: HeaderCarrier))
-      .expects(nino, itmpFlag, eligibilityReason, source, accountNumber, *)
+  def mockEnrolmentStoreInsert(nino: NINO, itmpFlag: Boolean, eligibilityReason: Option[Int],
+                               source: String, accountNumber: Option[String], deleteFlag: Option[Boolean] = None)(result: Either[String, Unit]): Unit =
+    (enrolmentStore.insert(_: NINO, _: Boolean, _: Option[Int], _: String, _: Option[String], _: Option[Boolean])(_: HeaderCarrier))
+      .expects(nino, itmpFlag, eligibilityReason, source, accountNumber, deleteFlag, *)
       .returning(EitherT.fromEither[Future](result))
 
   def mockEnrolmentStoreGet(nino: NINO)(result: Either[String, EnrolmentStore.Status]): Unit =


### PR DESCRIPTION
PR to address partial accounts that are blocking users to enrol again, after their accounts have been deleted from downstream systems. Reasons for this has been explained in detail with comments and linked ticket under https://jira.tools.tax.service.gov.uk/browse/DLS-9402

Changes in this PR are a step in direction where we address deletions in alignment with when the deletions happen in downstream systems. Till then, we need a mechanism to unblock users and soft delete mechanism in this PR paves way towards the final change. Reasons for using deleteFlag has been mentioned in README and also here.

Changes might look like they need lot of testing, but the workflow is simple enough. Any other approach would require the same amount of testing, with the added risk that we could've mutated the key field like `nino`. Which is generally not recommended and deleteFlag pattern being followed for soft deletes.

New test scenarios added to the store cover the different cases that we have taken into consideration for both deletions and undoing deletions.

Config processing is split into 2 stages for deletions and undoing deletions because of following reason:

Though I personally don't see a valid reason we would undo an enrolment when the source of that in downstream has been deleted. Logic has been included based on ask/discussions we've had around this. Because, data lineage with downstream systems is always abt looking ahead rather than mutating previous state. 

However, consider that undoing is a valid requirement and business usecase. Then, there will be a case of undoing deletions where the user has an active enrolment with 1 or more previous soft delete tagged enrolments. And, we now want to undo deletion for one of the 2 enrolments that are soft deleted. In that case, we can't risk undoing deletion without marking the current one as deleted, otherwise it would present us with multiple enrolments that are active. 

So, to make the process simple it would be ideal to have separate config processing for deletions and undoing them, as they can be sequentially done by following config

```
enrolment.delete-ninos=[{"nino": "nino-to-delete"}]
enrolment.undo-delete-ninos=[{"nino": "nino-to-delete", "docId": "doc-id-of-enrolement-version-to-become-active"}]

```

As these actions are processed sequentially, at end of the run, there will only be a single active enrolment against that nino. Approach to rely on doc id puts a dependency on knowing which of the enrolments we want to undo deletion for and make it active.This step of relying on access to live data is anyway needed with other alternate approaches (like prefixing NINOs). Because, prefixes doesn't have context on the enrolment and to know which prefix (with an infix increment) needs to be reverted involves assessing live data and then including that in config.