### PR TITLE
DLS-11488 | Update threshold value to be config driven

### DIFF
--- a/app/uk/gov/hmrc/helptosave/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/helptosave/config/AppConfig.scala
@@ -23,6 +23,7 @@ import play.api.{Configuration, Environment, Mode}
 import uk.gov.hmrc.helptosave.models.NINODeletionConfig
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
+import java.time.LocalDate
 import javax.inject.Inject
 import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
@@ -50,6 +51,15 @@ class AppConfig @Inject()(
 
   val thresholdAskTimeout: FiniteDuration =
     runModeConfiguration.get[FiniteDuration]("uc-threshold.ask-timeout")
+
+  val useMDTPThresholdConfig: Boolean = {
+    val effectiveDate = LocalDate.parse(runModeConfiguration.get[String]("mdtp-threshold.effective-date"))
+    val isActive = runModeConfiguration.get[Boolean]("mdtp-threshold.active")
+
+    isActive && !LocalDate.now().isBefore(effectiveDate)
+  }
+
+  val mdtpThresholdAmount: Double = runModeConfiguration.get[Double]("mdtp-threshold.amount")
 
   val createAccountVersion: String = servicesConfig.getString("nsi.create-account.version")
 

--- a/app/uk/gov/hmrc/helptosave/modules/UCThresholdModule.scala
+++ b/app/uk/gov/hmrc/helptosave/modules/UCThresholdModule.scala
@@ -17,21 +17,31 @@
 package uk.gov.hmrc.helptosave.modules
 
 import com.google.inject.{AbstractModule, Inject, Singleton}
-import org.apache.pekko.actor.{ActorRef, ActorSystem}
-import play.api.Configuration
+import org.apache.pekko.actor.{ActorRef, ActorSystem, PoisonPill}
+import play.api.{Configuration, Environment}
 import uk.gov.hmrc.helptosave.actors.{TimeCalculatorImpl, UCThresholdConnectorProxyActor, UCThresholdManager}
 import uk.gov.hmrc.helptosave.connectors.DESConnector
 import uk.gov.hmrc.helptosave.util.{Logging, PagerDutyAlerting}
+import uk.gov.hmrc.helptosave.actors.UCThresholdManager.{GetThresholdValue, GetThresholdValueResponse}
 
 import java.time.{Clock, ZoneId}
+import org.apache.pekko.pattern.ask
+import uk.gov.hmrc.helptosave.config.AppConfig
 
-class UCThresholdModule extends AbstractModule {
-  override def configure(): Unit =
-    bind(classOf[ThresholdManagerProvider]).to(classOf[UCThresholdOrchestrator]).asEagerSingleton()
+import javax.inject.Provider
+import scala.concurrent.{ExecutionContext, Future}
+
+class UCThresholdModule(environment: Environment, configuration: Configuration) extends AbstractModule {
+  override def configure(): Unit = {
+    bind(classOf[UCThresholdOrchestrator]).asEagerSingleton()
+    bind(classOf[MDTPThresholdOrchestrator]).asEagerSingleton()
+
+    bind(classOf[ThresholdOrchestrator]).toProvider(classOf[ThresholdValueByConfigProvider]).asEagerSingleton()
+  }
 }
 
-trait ThresholdManagerProvider {
-  val thresholdManager: ActorRef
+trait ThresholdOrchestrator {
+  def getValue: Future[Option[Double]]
 }
 
 @Singleton
@@ -39,8 +49,8 @@ class UCThresholdOrchestrator @Inject()(
   system: ActorSystem,
   pagerDutyAlerting: PagerDutyAlerting,
   configuration: Configuration,
-  desConnector: DESConnector)
-    extends ThresholdManagerProvider with Logging {
+  desConnector: DESConnector)(implicit appConfig: AppConfig, ec: ExecutionContext)
+    extends ThresholdOrchestrator with Logging {
   private lazy val connectorProxy: ActorRef =
     system.actorOf(UCThresholdConnectorProxyActor.props(desConnector, pagerDutyAlerting))
 
@@ -49,7 +59,7 @@ class UCThresholdOrchestrator @Inject()(
     new TimeCalculatorImpl(clock)
   }
 
-  val thresholdManager: ActorRef = {
+  protected val thresholdManager: ActorRef = {
     logger.info("Starting UCThresholdManager")
     system.actorOf(
       UCThresholdManager.props(
@@ -59,5 +69,38 @@ class UCThresholdOrchestrator @Inject()(
         timeCalculator,
         configuration
       ))
+  }
+
+  override def getValue: Future[Option[Double]] = {
+    thresholdManager
+      .ask(GetThresholdValue)(appConfig.thresholdAskTimeout)
+      .mapTo[GetThresholdValueResponse]
+      .map(r => r.result)
+  }
+
+  def stop(): Unit = {
+    thresholdManager ! PoisonPill
+  }
+}
+
+@Singleton
+class MDTPThresholdOrchestrator @Inject()(appConfig: AppConfig) extends ThresholdOrchestrator {
+  override def getValue: Future[Option[Double]] = {
+    Future.successful(Some(appConfig.mdtpThresholdAmount))
+  }
+}
+
+@Singleton
+class ThresholdValueByConfigProvider @Inject()(
+  appConfig: AppConfig,
+  desThresholdProvider: Provider[UCThresholdOrchestrator],
+  mdtpThresholdProvider: Provider[MDTPThresholdOrchestrator]
+) extends Provider[ThresholdOrchestrator] {
+
+  def get: ThresholdOrchestrator = {
+    if (appConfig.useMDTPThresholdConfig) {
+      desThresholdProvider.get().stop()
+      mdtpThresholdProvider.get()
+    } else desThresholdProvider.get()
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -54,7 +54,7 @@ bootstrap.http.Allowlist += ${microservice.correlationIdHeaderName}
 
 # The application languages
 # ~~~~~
-play.i18n.langs = [ "en"]
+play.i18n.langs = ["en"]
 
 # Router
 # ~~~~~
@@ -202,6 +202,12 @@ stride {
     update-timezone   = "Europe/London"
     update-time       = "00:00"
     update-time-delay = "30 minutes"
+  }
+
+  mdtp-threshold {
+    active = true
+    effective-date = "2025-04-06"
+    amount = 1
   }
 
 enrolment {

--- a/test/uk/gov/hmrc/helptosave/modules/ThresholdValueByConfigProviderSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/modules/ThresholdValueByConfigProviderSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.helptosave.modules
+
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.play.guice.GuiceOneAppPerTest
+import play.api.test.Helpers.running
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.{Application, Configuration, Environment}
+
+class ThresholdValueByConfigProviderSpec extends AnyWordSpec with Matchers with GuiceOneAppPerTest {
+  def buildTestApp(isMDTPConfigActive: Boolean, effectiveDate: String): Application = {
+    GuiceApplicationBuilder()
+      .configure(
+        "mdtp-threshold.active" -> isMDTPConfigActive,
+        "mdtp-threshold.effective-date" -> effectiveDate,
+        "metrics.jvm" -> false
+      )
+      .bindings(new UCThresholdModule(Environment.simple(), Configuration.empty))
+      .build()
+  }
+
+  "ThresholdValueByConfigProvider" should {
+    "use MDTP threshold config if today is after effective date and MDTP threshold config is active" in {
+      val app = buildTestApp(isMDTPConfigActive = true, effectiveDate = "2000-01-01")
+
+      running(app) {
+        val thresholdOrchestrator = app.injector.instanceOf[ThresholdOrchestrator]
+        thresholdOrchestrator shouldBe a[MDTPThresholdOrchestrator]
+      }
+    }
+
+    "use UC ThresholdManager actor if MDTP threshold config is inactive (regardless of effective date)" in {
+      val app = buildTestApp(isMDTPConfigActive = false, effectiveDate = "2000-01-01")
+
+      running(app) {
+        val thresholdOrchestrator = app.injector.instanceOf[ThresholdOrchestrator]
+        thresholdOrchestrator shouldBe a[UCThresholdOrchestrator]
+      }
+    }
+
+    "use UC ThresholdManager actor if MDTP threshold config is active but today is before effective date" in {
+      val app = buildTestApp(isMDTPConfigActive = true, effectiveDate = "2999-12-31")
+
+      running(app) {
+        val thresholdOrchestrator = app.injector.instanceOf[ThresholdOrchestrator]
+        thresholdOrchestrator shouldBe a[UCThresholdOrchestrator]
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/helptosave/modules/UCThresholdOrchestratorSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/modules/UCThresholdOrchestratorSpec.scala
@@ -18,13 +18,12 @@ package uk.gov.hmrc.helptosave.modules
 
 import com.typesafe.config.ConfigFactory
 import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.pattern.ask
 import org.apache.pekko.util.Timeout
 import org.mockito.ArgumentMatchersSugar.*
 import org.scalatest.concurrent.{Eventually, PatienceConfiguration}
 import play.api.Configuration
 import play.api.libs.json.Json
-import uk.gov.hmrc.helptosave.actors.{ActorTestSupport, UCThresholdConnectorProxyActor, UCThresholdManager}
+import uk.gov.hmrc.helptosave.actors.{ActorTestSupport, UCThresholdConnectorProxyActor}
 import uk.gov.hmrc.helptosave.connectors.DESConnector
 import uk.gov.hmrc.helptosave.services.HelpToSaveService
 import uk.gov.hmrc.helptosave.util.PagerDutyAlerting
@@ -68,10 +67,7 @@ class UCThresholdOrchestratorSpec extends ActorTestSupport("UCThresholdOrchestra
       val orchestrator = new UCThresholdOrchestrator(system, pagerDutyAlert, testConfiguration, connector)
 
       eventually(PatienceConfiguration.Timeout(10.seconds), PatienceConfiguration.Interval(1.second)) {
-        val response = (orchestrator.thresholdManager ? UCThresholdManager.GetThresholdValue)
-          .mapTo[UCThresholdManager.GetThresholdValueResponse]
-
-        Await.result(response, 1.second).result shouldBe Some(threshold)
+        Await.result(orchestrator.getValue, 1.second) shouldBe Some(threshold)
       }
 
       // sleep here to ensure the mock ThresholdStore's storeUCThreshold method


### PR DESCRIPTION
- Include new threshold provider that is MDTP config driven.
- Toggle threshold provider based on feature flag and configuration made available.
- Not removing old actor model threshold retrieval till we are live and business is happy with the change.
- From  new tax year start date (06/04/2025), the actor will be stopped alongside the MDTP provider retrieval.