### PR TITLE
DLS-11580 | Revert to authProvider retrievals

### DIFF
--- a/test/uk/gov/hmrc/helptosave/controllers/AccountControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/controllers/AccountControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, *}
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
-import uk.gov.hmrc.auth.core.retrieve.{Credentials, v2}
+import uk.gov.hmrc.auth.core.retrieve.{GGCredId, v2}
 import uk.gov.hmrc.helptosave.connectors.HelpToSaveProxyConnector
 import uk.gov.hmrc.helptosave.controllers.HelpToSaveAuth.GGAndPrivilegedProviders
 import uk.gov.hmrc.helptosave.models.account.{Account, Blocking}
@@ -85,8 +85,7 @@ class AccountControllerSpec extends AuthSupport {
       }
 
       "return a 403 (FORBIDDEN) if the NINO in the URL doesn't match the NINO retrieved from auth" in {
-        val ggCredentials = Some(Credentials("id", "GovernmentGateway"))
-        mockAuth(GGAndPrivilegedProviders, v2.Retrievals.credentials)(Right(ggCredentials))
+        mockAuth(GGAndPrivilegedProviders, v2.Retrievals.authProviderId)(Right(GGCredId("id")))
         mockAuth(EmptyPredicate, v2.Retrievals.nino)(Right(mockedNinoRetrieval))
 
         val result = controller.getAccount("BE123456C", systemId, None)(fakeRequest)

--- a/test/uk/gov/hmrc/helptosave/controllers/AuthSupport.scala
+++ b/test/uk/gov/hmrc/helptosave/controllers/AuthSupport.scala
@@ -46,19 +46,16 @@ trait AuthSupport extends TestSupport {
       .thenAnswer(_ => result.fold(e => Future.failed[A](e), r => Future.successful(r)))
 
   def testWithGGAndPrivilegedAccess(f: (() => Unit) => Unit): Unit = {
-    val ggCredentials: Option[Credentials]         = Some(Credentials("id", "GovernmentGateway"))
-    val privilegedCredentials: Option[Credentials] = Some(Credentials("id", "PrivilegedApplication"))
-
     withClue("For GG access: ") {
       f { () =>
-        mockAuth(GGAndPrivilegedProviders, v2.Retrievals.credentials)(Right(ggCredentials))
+        mockAuth(GGAndPrivilegedProviders, v2.Retrievals.authProviderId)(Right(GGCredId("id")))
         mockAuth(EmptyPredicate, v2.Retrievals.nino)(Right(Some(nino)))
       }
     }
 
     withClue("For privileged access: ") {
       f { () =>
-        mockAuth(GGAndPrivilegedProviders, v2.Retrievals.credentials)(Right(privilegedCredentials))
+        mockAuth(GGAndPrivilegedProviders, v2.Retrievals.authProviderId)(Right(PAClientId("id")))
       }
     }
   }

--- a/test/uk/gov/hmrc/helptosave/controllers/EligibilityCheckerControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/controllers/EligibilityCheckerControllerSpec.scala
@@ -25,8 +25,8 @@ import play.api.libs.json.Json
 import play.api.mvc.Result as PlayResult
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
-import uk.gov.hmrc.auth.core.retrieve.Credentials
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{credentials, nino as v2Nino}
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{authProviderId, nino => v2Nino}
+import uk.gov.hmrc.auth.core.retrieve.{GGCredId, PAClientId}
 import uk.gov.hmrc.helptosave.controllers.HelpToSaveAuth.*
 import uk.gov.hmrc.helptosave.models.*
 import uk.gov.hmrc.helptosave.services.HelpToSaveService
@@ -50,18 +50,18 @@ class EligibilityCheckerControllerSpec extends StrideAuthSupport with ScalaCheck
 
     val controller = new EligibilityCheckController(eligibilityService, mockAuthConnector, testCC)
 
-    val privilegedCredentials: Option[Credentials] = Some(Credentials("id", "PrivilegedApplication"))
+    val privilegedCredentials: PAClientId = PAClientId("id")
   }
 
   "The EligibilityCheckerController" when {
 
-    val ggCredentials = Some(Credentials("123-gg", "GovernmentGateway"))
+    val ggCredentials = GGCredId("123-gg")
     val eligibility   = EligibilityCheckResponse(EligibilityCheckResult("x", 0, "y", 0), Some(123.45))
 
     "handling requests to perform eligibility checks" must {
 
       "return with a status 500 if the eligibility check service fails" in new TestApparatus {
-        mockAuth(GGAndPrivilegedProviders, credentials)(Right(ggCredentials))
+        mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(ggCredentials))
         mockAuth(v2Nino)(Right(mockedNinoRetrieval))
         mockEligibilityCheckerService(nino, routes.EligibilityCheckController.eligibilityCheck(Some(nino)).url)(
           Left("The Eligibility Check service is unavailable")
@@ -73,7 +73,7 @@ class EligibilityCheckerControllerSpec extends StrideAuthSupport with ScalaCheck
 
       "return the eligibility status returned from the eligibility check service if " +
         "successful" in new TestApparatus {
-          mockAuth(GGAndPrivilegedProviders, credentials)(Right(ggCredentials))
+          mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(ggCredentials))
           mockAuth(v2Nino)(Right(mockedNinoRetrieval))
           mockEligibilityCheckerService(nino, routes.EligibilityCheckController.eligibilityCheck(Some(nino)).url)(
             Right(eligibility)
@@ -85,7 +85,7 @@ class EligibilityCheckerControllerSpec extends StrideAuthSupport with ScalaCheck
         }
 
       "return Forbidden if the ggNino does not match the given nino" in new TestApparatus {
-        mockAuth(GGAndPrivilegedProviders, credentials)(Right(ggCredentials))
+        mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(ggCredentials))
         mockAuth(v2Nino)(Right(mockedNinoRetrieval))
 
         val result: Future[PlayResult] = doRequest(controller, Some("AE121212A"))
@@ -94,7 +94,7 @@ class EligibilityCheckerControllerSpec extends StrideAuthSupport with ScalaCheck
 
       "return the eligibility status returned from the eligibility check service successfully when no nino is given" in
         new TestApparatus {
-          mockAuth(GGAndPrivilegedProviders, credentials)(Right(ggCredentials))
+          mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(ggCredentials))
           mockAuth(v2Nino)(Right(mockedNinoRetrieval))
           mockEligibilityCheckerService(nino, routes.EligibilityCheckController.eligibilityCheck(None).url)(
             Right(eligibility)
@@ -110,7 +110,7 @@ class EligibilityCheckerControllerSpec extends StrideAuthSupport with ScalaCheck
     "handling requests to perform stride or API eligibility checks" must {
 
       "ask the EligibilityCheckerService if the user is eligible and return the result" in new TestApparatus {
-        mockAuth(GGAndPrivilegedProviders, credentials)(Right(privilegedCredentials))
+        mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(privilegedCredentials))
         mockEligibilityCheckerService(nino, routes.EligibilityCheckController.eligibilityCheck(Some(nino)).url)(
           Right(eligibility)
         )
@@ -121,7 +121,7 @@ class EligibilityCheckerControllerSpec extends StrideAuthSupport with ScalaCheck
       }
 
       "return with a 500 status if the eligibility check service fails" in new TestApparatus {
-        mockAuth(GGAndPrivilegedProviders, credentials)(Right(privilegedCredentials))
+        mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(privilegedCredentials))
         mockEligibilityCheckerService(nino, routes.EligibilityCheckController.eligibilityCheck(Some(nino)).url)(
           Left("The Eligibility Check service is unavailable")
         )
@@ -131,7 +131,7 @@ class EligibilityCheckerControllerSpec extends StrideAuthSupport with ScalaCheck
       }
 
       "return a Bad Request(400) status if there was no nino given" in new TestApparatus {
-        mockAuth(GGAndPrivilegedProviders, credentials)(Right(privilegedCredentials))
+        mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(privilegedCredentials))
 
         val result: Future[PlayResult] = doRequest(controller, None)
         status(result) shouldBe 400

--- a/test/uk/gov/hmrc/helptosave/controllers/EmailStoreControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/controllers/EmailStoreControllerSpec.scala
@@ -25,8 +25,8 @@ import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
-import uk.gov.hmrc.auth.core.retrieve.Credentials
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{credentials, nino as v2Nino}
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{authProviderId => v2AuthProviderId, nino => v2Nino}
+import uk.gov.hmrc.auth.core.retrieve.{GGCredId, PAClientId}
 import uk.gov.hmrc.helptosave.controllers.HelpToSaveAuth.*
 import uk.gov.hmrc.helptosave.repo.EmailStore
 import uk.gov.hmrc.helptosave.util.NINO
@@ -56,11 +56,8 @@ class EmailStoreControllerSpec extends AuthSupport {
       controller.store(email, nino)(FakeRequest())
 
     "handling requests to store emails" must {
-      val ggCredentials         = Some(Credentials("", "GovernmentGateway"))
-      val privilegedCredentials = Some(Credentials("", "PrivilegedApplication"))
-
       "return a HTTP 200 if the email is successfully stored with a GG login" in {
-        mockAuth(GGAndPrivilegedProviders, credentials)(Right(ggCredentials))
+        mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(GGCredId("")))
         mockAuth(EmptyPredicate, v2Nino)(Right(Some(nino)))
         mockStore(email, nino)(Right(()))
 
@@ -68,7 +65,7 @@ class EmailStoreControllerSpec extends AuthSupport {
       }
 
       "return a HTTP 200 if the email is successfully stored with a privileged login" in {
-        mockAuth(GGAndPrivilegedProviders, credentials)(Right(privilegedCredentials))
+        mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(PAClientId("")))
         mockStore(email, nino)(Right(()))
 
         status(store(encodedEmail, Some(nino))) shouldBe 200
@@ -77,13 +74,13 @@ class EmailStoreControllerSpec extends AuthSupport {
       "return a HTTP 500" when {
 
         "the email cannot be decoded" in {
-          mockAuth(GGAndPrivilegedProviders, credentials)(Right(privilegedCredentials))
+          mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(PAClientId("")))
 
           status(store("not base 64 encoded", Some(nino))) shouldBe 500
         }
 
         "the email is not successfully stored" in {
-          mockAuth(GGAndPrivilegedProviders, credentials)(Right(privilegedCredentials))
+          mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(PAClientId("")))
           mockStore(email, nino)(Left(""))
 
           status(store(encodedEmail, Some(nino))) shouldBe 500

--- a/test/uk/gov/hmrc/helptosave/controllers/EnrolmentStoreControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/controllers/EnrolmentStoreControllerSpec.scala
@@ -26,8 +26,8 @@ import play.api.libs.json.{JsSuccess, JsValue, Json}
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
-import uk.gov.hmrc.auth.core.retrieve.Credentials
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{credentials, nino as v2Nino}
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{authProviderId, nino => v2Nino}
+import uk.gov.hmrc.auth.core.retrieve.{GGCredId, PAClientId}
 import uk.gov.hmrc.helptosave.controllers.HelpToSaveAuth.*
 import uk.gov.hmrc.helptosave.models.account.{Account, AccountNumber}
 import uk.gov.hmrc.helptosave.models.enrolment.{Enrolled, NotEnrolled, Status}
@@ -48,8 +48,8 @@ class EnrolmentStoreControllerSpec
       )
     )
 
-  val ggCredentials: Option[Credentials]         = Some(Credentials("123-gg", "GovernmentGateway"))
-  val privilegedCredentials: Option[Credentials] = Some(Credentials("id", "PrivilegedApplication"))
+  val privilegedCredentials: PAClientId = PAClientId("id")
+  val ggCredentials: GGCredId           = GGCredId("123-gg")
 
   def mockGetAccountFromNSI(nino: String, systemId: String, correlationId: String, path: String)(
     result: Either[String, Option[Account]]
@@ -162,7 +162,7 @@ class EnrolmentStoreControllerSpec
         controller.getEnrolmentStatus(nino)(FakeRequest())
 
       "get the enrolment status from the enrolment store" in {
-        mockAuth(GGAndPrivilegedProviders, credentials)(Right(ggCredentials))
+        mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(ggCredentials))
         mockAuth(v2Nino)(Right(mockedNinoRetrieval))
         mockEnrolmentStoreGet(nino)(Left(""))
 
@@ -195,7 +195,7 @@ class EnrolmentStoreControllerSpec
         )
 
         m.foreach { case (s, j) =>
-          mockAuth(GGAndPrivilegedProviders, credentials)(Right(ggCredentials))
+          mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(ggCredentials))
           mockAuth(v2Nino)(Right(mockedNinoRetrieval))
           mockEnrolmentStoreGet(nino)(Right(s))
 
@@ -206,7 +206,7 @@ class EnrolmentStoreControllerSpec
       }
 
       "return an error if the call was not successful" in {
-        mockAuth(GGAndPrivilegedProviders, credentials)(Right(ggCredentials))
+        mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(ggCredentials))
         mockAuth(v2Nino)(Right(mockedNinoRetrieval))
         mockEnrolmentStoreGet(nino)(Left(""))
 
@@ -222,7 +222,7 @@ class EnrolmentStoreControllerSpec
           Enrolled(itmpHtSFlag = false),
           NotEnrolled
         ).foreach { status =>
-          mockAuth(GGAndPrivilegedProviders, credentials)(Right(privilegedCredentials))
+          mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(privilegedCredentials))
           mockEnrolmentStoreGet(nino)(Right(status))
 
           val result = controller.getEnrolmentStatus(Some(nino))(FakeRequest())
@@ -231,7 +231,7 @@ class EnrolmentStoreControllerSpec
       }
 
       "return an error if there is a problem getting the enrolment status" in {
-        mockAuth(GGAndPrivilegedProviders, credentials)(Right(privilegedCredentials))
+        mockAuth(GGAndPrivilegedProviders, authProviderId)(Right(privilegedCredentials))
         mockEnrolmentStoreGet(nino)(Left(""))
 
         val result = controller.getEnrolmentStatus(Some(nino))(FakeRequest())

--- a/test/uk/gov/hmrc/helptosave/controllers/HelpToSaveAuthSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/controllers/HelpToSaveAuthSpec.scala
@@ -22,7 +22,7 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core.AuthorisationException.fromString
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.retrieve._
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{credentials => v2Credentials, nino => v2Nino}
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{authProviderId => v2AuthProviderId, nino => v2Nino}
 import uk.gov.hmrc.helptosave.controllers.HelpToSaveAuth._
 
 import scala.concurrent.Future
@@ -102,38 +102,38 @@ class HelpToSaveAuthSpec extends AuthSupport {
 
       "handling GG requests" when {
 
-        val ggCredentials = Some(Credentials("", "GovernmentGateway"))
+        val ggCredentials = GGCredId("")
 
         "retrieve a NINO and return successfully if the given NINO and retrieved NINO match" in {
-          mockAuth(GGAndPrivilegedProviders, v2Credentials)(Right(ggCredentials))
+          mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(ggCredentials))
           mockAuth(EmptyPredicate, v2Nino)(Right(Some("nino")))
 
           status(callAuth(Some("nino"))(FakeRequest())) shouldBe Status.OK
         }
 
         "retrieve a NINO and return successfully if a NINO is not given and a NINO is successfully retrieved" in {
-          mockAuth(GGAndPrivilegedProviders, v2Credentials)(Right(ggCredentials))
+          mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(ggCredentials))
           mockAuth(EmptyPredicate, v2Nino)(Right(Some("nino")))
 
           status(callAuth(None)(FakeRequest())) shouldBe Status.OK
         }
 
         "retrieve a NINO and return a Forbidden if the given NINO and the retrieved NINO do not match" in {
-          mockAuth(GGAndPrivilegedProviders, v2Credentials)(Right(ggCredentials))
+          mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(ggCredentials))
           mockAuth(EmptyPredicate, v2Nino)(Right(Some("other-nino")))
 
           status(callAuth(Some("nino"))(FakeRequest())) shouldBe Status.FORBIDDEN
         }
 
         "return a Forbidden if a NINO could not be found and a NINO was given" in {
-          mockAuth(GGAndPrivilegedProviders, v2Credentials)(Right(ggCredentials))
+          mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(ggCredentials))
           mockAuth(EmptyPredicate, v2Nino)(Right(None))
 
           status(callAuth(Some("nino"))(FakeRequest())) shouldBe Status.FORBIDDEN
         }
 
         "return a Forbidden if a NINO could not be found and a NINO was not given" in {
-          mockAuth(GGAndPrivilegedProviders, v2Credentials)(Right(ggCredentials))
+          mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(ggCredentials))
           mockAuth(EmptyPredicate, v2Nino)(Right(None))
 
           status(callAuth(None)(FakeRequest())) shouldBe Status.FORBIDDEN
@@ -142,15 +142,15 @@ class HelpToSaveAuthSpec extends AuthSupport {
 
       "handling PrivilegedApplication requests" must {
 
-        val privilegedCredentials = Some(Credentials("", "PrivilegedApplication"))
+        val privilegedCredentials = PAClientId("")
 
         "return a BadRequest if no NINO is given" in {
-          mockAuth(GGAndPrivilegedProviders, v2Credentials)(Right(privilegedCredentials))
+          mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(privilegedCredentials))
           status(callAuth(None)(FakeRequest())) shouldBe Status.BAD_REQUEST
         }
 
         "return successfully if a NINO is given" in {
-          mockAuth(GGAndPrivilegedProviders, v2Credentials)(Right(privilegedCredentials))
+          mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(privilegedCredentials))
           status(callAuth(Some("nino"))(FakeRequest())) shouldBe Status.OK
         }
 
@@ -159,8 +159,8 @@ class HelpToSaveAuthSpec extends AuthSupport {
       "handling requests from other AuthProviders" must {
 
         "return a Forbidden" in {
-          List[Credentials](Credentials("", "StandardApplication"), Credentials("", "OneTimeLogin")).foreach { cred =>
-            mockAuth(GGAndPrivilegedProviders, v2Credentials)(Right(Some(cred)))
+          List[LegacyCredentials](StandardApplication(""), OneTimeLogin).foreach { cred =>
+            mockAuth(GGAndPrivilegedProviders, v2AuthProviderId)(Right(cred))
             status(callAuth(Some("nino"))(FakeRequest())) shouldBe Status.FORBIDDEN
           }
 

--- a/test/uk/gov/hmrc/helptosave/controllers/TransactionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/controllers/TransactionsControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, *}
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
-import uk.gov.hmrc.auth.core.retrieve.{Credentials, v2}
+import uk.gov.hmrc.auth.core.retrieve.{GGCredId, v2}
 import uk.gov.hmrc.helptosave.connectors.HelpToSaveProxyConnector
 import uk.gov.hmrc.helptosave.controllers.HelpToSaveAuth.GGAndPrivilegedProviders
 import uk.gov.hmrc.helptosave.models.account.*
@@ -79,9 +79,7 @@ class TransactionsControllerSpec extends AuthSupport {
       }
 
       "return a 403 (FORBIDDEN) if the NINO in the URL doesn't match the NINO retrieved from auth" in {
-        val ggCredentials = Some(Credentials("id", "GovernmentGateway"))
-
-        mockAuth(GGAndPrivilegedProviders, v2.Retrievals.credentials)(Right(ggCredentials))
+        mockAuth(GGAndPrivilegedProviders, v2.Retrievals.authProviderId)(Right(GGCredId("id")))
         mockAuth(EmptyPredicate, v2.Retrievals.nino)(Right(mockedNinoRetrieval))
 
         val result = controller.getTransactions("BE123456C", systemId, None)(fakeRequest)

--- a/test/uk/gov/hmrc/helptosave/models/PayePersonalDetailsSpec.scala
+++ b/test/uk/gov/hmrc/helptosave/models/PayePersonalDetailsSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.helptosave.models
 
 import play.api.libs.json.{JsError, JsSuccess, Json}
-import uk.gov.hmrc.helptosave.models.PayePersonalDetails._
+import uk.gov.hmrc.helptosave.models.PayePersonalDetails.*
 import uk.gov.hmrc.helptosave.utils.{TestData, TestSupport}
 
 import java.time.LocalDate


### PR DESCRIPTION
- `help-to-save-integration-tests` were broken with the auth retrieval change to use credentials. This change will require further work on getting the auth updated as part of integration tests and felt it's better to shift this to another story than having the `help-to-save` pipeline unhealthy.
- No functional changes, just revert back to using authProvider retrievals.